### PR TITLE
Expect non-padded crypto profile key in SDP (fallback to padded)

### DIFF
--- a/sdp/offer.go
+++ b/sdp/offer.go
@@ -399,9 +399,12 @@ func parseSRTPProfile(val string) (*srtp.Profile, error) {
 	if !ok {
 		return nil, nil // ignore
 	}
-	keys, err := base64.StdEncoding.WithPadding(base64.StdPadding).DecodeString(skey)
+	keys, err := base64.RawStdEncoding.DecodeString(skey)
 	if err != nil {
-		return nil, fmt.Errorf("cannot parse crypto key %q: %v", skey, err)
+		// Fallback to padded encoding if raw fails
+		if keys, err = base64.StdEncoding.DecodeString(skey); err != nil {
+			return nil, fmt.Errorf("cannot parse crypto key %q: %v", skey, err)
+		}
 	}
 	var salt []byte
 	if sp, err := prof.Parse(); err == nil {


### PR DESCRIPTION
RFC 4568 section 6.1:

```
When base64 decoding the key and salt, padding characters (i.e., one
or two "=" at the end of the base64-encoded data) are discarded
```