### PR TITLE
Exposing jitter options on RTP handler, minor timestamp fix

### DIFF
--- a/jitter/buffer.go
+++ b/jitter/buffer.go
@@ -288,7 +288,7 @@ func (b *Buffer) popReady() {
 
 		if b.head.extPacket.SequenceNumber == b.prevSN+1 || b.head.discont || !b.initialized {
 			// normal
-		} else if b.head.extPacket.ReceivedAt.Before(expiry) {
+		} else if !expiry.Before(b.head.extPacket.ReceivedAt) {
 			// max latency reached
 			loss = true
 			b.stats.PacketsLost += uint64(b.head.extPacket.SequenceNumber - b.prevSN - 1)

--- a/rtp/jitter.go
+++ b/rtp/jitter.go
@@ -26,7 +26,7 @@ const (
 	jitterMaxLatency = 60 * time.Millisecond // should match mixer's target buffer size
 )
 
-func HandleJitter(h HandlerCloser) HandlerCloser {
+func HandleJitter(h HandlerCloser, opts ...jitter.Option) HandlerCloser {
 	handler := &jitterHandler{
 		h:   h,
 		err: make(chan error, 1),
@@ -37,7 +37,7 @@ func HandleJitter(h HandlerCloser) HandlerCloser {
 		for _, p := range packets {
 			handler.handleRTP(p.Packet)
 		}
-	})
+	}, opts...)
 	return handler
 }
 


### PR DESCRIPTION
The timing issue happens with [synctest](https://go.dev/blog/synctest) (shoutout Denys for the pointer!) and unfolds as follows:
- Timer wakes us up at expiry of first packet.
- Because time.Now() == b.head.extPacket.ReceivedAt + b.latency, we would not emit the packet in the current code.
- We schedule timer for expiry of first packet (`== time.Now()`).
- Rinse, repeat. Infinite loop.

This does not happen with real-world timers since time actually advances while we process things, and by the time we check `time.Now()` in `popReady()`, now is already advanced by at least a nanosecond, thus the condition releases the packet.

Passing jitter.Option to HandleJitter is to expose the onLoss options for test accounting purposes.