### PR TITLE
exposing attributes

### DIFF
--- a/rtp/rtp.go
+++ b/rtp/rtp.go
@@ -119,6 +119,7 @@ func NewSeqWriter(w Writer) *SeqWriter {
 
 type Packet = rtp.Packet
 type Header = rtp.Header
+type Attributes = interceptor.Attributes
 
 type Event struct {
 	Type      byte


### PR DESCRIPTION
The other option was to include sometthing like the following:
```go
type RTPWriteInterceptor interface {
	Write(header *rtp.Header, payload []byte, attributes interceptor.Attributes) (int, error)
}
```
but that felt a little too specific. LMK if you'd like to add that too.