### PR TITLE
Add codec sets that could overlay global config.

### DIFF
--- a/codecs.go
+++ b/codecs.go
@@ -26,7 +26,8 @@ type CodecInfo struct {
 	RTPDefType   byte
 	RTPIsStatic  bool
 	Priority     int
-	Disabled     bool
+	Disabled     bool // codec is disabled in GlobalCodecs by default
+	Hidden       bool // codec should not appear in SDP offer, but can be used in the answer
 	FileExt      string
 }
 
@@ -35,68 +36,131 @@ type Codec interface {
 }
 
 var (
-	disabled        = make(map[string]struct{})
+	globalSet       = NewCodecSet()
 	codecs          []Codec
 	codecOnRegister []func(c Codec)
 )
 
-func CodecSetEnabled(name string, enabled bool) {
+// GlobalCodecs returns a shared codec set.
+func GlobalCodecs() *CodecSet {
+	return globalSet
+}
+
+// NewCodecSet creates an empty codec set. All codecs are disabled, unless enabled explicitly.
+func NewCodecSet() *CodecSet {
+	return &CodecSet{
+		enabled: make(map[string]bool),
+	}
+}
+
+// CodecSet represents a set of codecs that can be enabled or disabled.
+type CodecSet struct {
+	parent  *CodecSet
+	enabled map[string]bool
+}
+
+// NewSet creates a codec set that overlays the current codec set.
+// It will inherit all codecs enabled in the parent set.
+func (s *CodecSet) NewSet() *CodecSet {
+	c2 := NewCodecSet()
+	c2.parent = s
+	return c2
+}
+
+// SetEnabled enables or disables a given codec.
+func (s *CodecSet) SetEnabled(name string, enabled bool) {
 	name = strings.ToLower(name)
-	if enabled {
-		delete(disabled, name)
-	} else {
-		disabled[name] = struct{}{}
-	}
+	s.enabled[name] = enabled
 }
 
-func CodecsSetEnabled(codecs map[string]bool) {
+// SetEnabledMap is the same as SetEnabled, but accepts a map with multiple codecs.
+func (s *CodecSet) SetEnabledMap(codecs map[string]bool) {
 	for name, enabled := range codecs {
-		CodecSetEnabled(name, enabled)
+		s.SetEnabled(name, enabled)
 	}
 }
 
-func CodecEnabled(c Codec) bool {
-	if c == nil {
+// IsEnabledByName checks if a given codec is enabled by its name.
+func (s *CodecSet) IsEnabledByName(name string) bool {
+	if s == nil {
 		return false
 	}
-	return CodecEnabledByName(c.Info().SDPName)
-}
-
-func CodecEnabledByName(name string) bool {
 	name = strings.ToLower(name)
-	_, dis := disabled[name]
-	return !dis
-}
-
-func OnRegister(fnc func(c Codec)) {
-	for _, c := range codecs {
-		fnc(c)
+	for s := s; s != nil; s = s.parent {
+		if enabled, ok := s.enabled[name]; ok {
+			return enabled
+		}
 	}
-	codecOnRegister = append(codecOnRegister, fnc)
+	return false
 }
 
-func Codecs() []Codec {
-	return slices.Clone(codecs)
+// IsEnabled checks if a given codec is enabled.
+func (s *CodecSet) IsEnabled(c Codec) bool {
+	if s == nil || c == nil {
+		return false
+	}
+	return s.IsEnabledByName(c.Info().SDPName)
 }
 
-func EnabledCodecs() []Codec {
+// ListEnabled lists all enabled codecs.
+func (s *CodecSet) ListEnabled() []Codec {
+	if s == nil {
+		return nil
+	}
 	out := make([]Codec, 0, len(codecs))
 	for _, c := range codecs {
-		name := strings.ToLower(c.Info().SDPName)
-		if _, ok := disabled[name]; ok {
-			continue
+		if s.IsEnabled(c) {
+			out = append(out, c)
 		}
-		out = append(out, c)
 	}
 	return out
 }
 
+// CodecSetEnabled enables or disables a codec in the GlobalCodecs set.
+func CodecSetEnabled(name string, enabled bool) {
+	GlobalCodecs().SetEnabled(name, enabled)
+}
+
+// CodecsSetEnabled enables or disables multiple codecs in the GlobalCodecs set.
+func CodecsSetEnabled(codecs map[string]bool) {
+	GlobalCodecs().SetEnabledMap(codecs)
+}
+
+// CodecEnabled checks if the codec is enabled in the GlobalCodecs set.
+func CodecEnabled(c Codec) bool {
+	return GlobalCodecs().IsEnabled(c)
+}
+
+// CodecEnabledByName checks if the codec name is enabled in the GlobalCodecs set.
+func CodecEnabledByName(name string) bool {
+	return GlobalCodecs().IsEnabledByName(name)
+}
+
+func OnRegister(fnc func(c Codec)) {
+	// Call it on already registered codecs first, so that the import order doesn't matter.
+	for _, c := range codecs {
+		fnc(c)
+	}
+	// Add the function for codecs that will be registered next.
+	codecOnRegister = append(codecOnRegister, fnc)
+}
+
+// Codecs lists all registered codecs.
+func Codecs() []Codec {
+	return slices.Clone(codecs)
+}
+
+// EnabledCodecs lists all codecs enabled in the GlobalCodecs set.
+func EnabledCodecs() []Codec {
+	return GlobalCodecs().ListEnabled()
+}
+
 // RegisterCodec registers the codec.
 func RegisterCodec(c Codec) {
+	info := c.Info()
+	global := GlobalCodecs()
 	codecs = append(codecs, c)
-	if info := c.Info(); info.Disabled {
-		CodecSetEnabled(info.SDPName, false)
-	}
+	global.SetEnabled(info.SDPName, !info.Disabled)
 	for _, fnc := range codecOnRegister {
 		fnc(c)
 	}

--- a/sdp/codecs.go
+++ b/sdp/codecs.go
@@ -37,10 +37,22 @@ func init() {
 	})
 }
 
-func CodecByName(name string) media.Codec {
+// CodecByNameWith finds the codec with a given SDP name.
+// If the codec is not found or disabled in the codec set, it returns nil.
+func CodecByNameWith(s *media.CodecSet, name string) media.Codec {
+	if s == nil {
+		s = media.GlobalCodecs()
+	}
 	c := codecByName[strings.ToLower(name)]
-	if !media.CodecEnabled(c) {
+	if !s.IsEnabled(c) {
 		return nil
 	}
 	return c
+}
+
+// CodecByName finds the codec with a given SDP name.
+//
+// Deprecated: use CodecByNameWith
+func CodecByName(name string) media.Codec {
+	return CodecByNameWith(media.GlobalCodecs(), name)
 }

--- a/sdp/offer.go
+++ b/sdp/offer.go
@@ -52,9 +52,13 @@ type CodecInfo struct {
 	Codec media.Codec
 }
 
-func OfferCodecs() []CodecInfo {
+// OfferCodecsWith lists enabled codecs in the set for the SDP offer and assigns payload types to them.
+func OfferCodecsWith(s *media.CodecSet) []CodecInfo {
+	if s == nil {
+		s = media.GlobalCodecs()
+	}
 	const dynamicType = 101
-	codecs := media.EnabledCodecs()
+	codecs := s.ListEnabled()
 	slices.SortFunc(codecs, func(a, b media.Codec) int {
 		ai, bi := a.Info(), b.Info()
 		if ai.RTPIsStatic != bi.RTPIsStatic {
@@ -85,6 +89,13 @@ func OfferCodecs() []CodecInfo {
 	return infos
 }
 
+// OfferCodecs is the same as OfferCodecsWith called with media.GlobalCodecs().
+//
+// Deprecated: use OfferCodecsWith
+func OfferCodecs() []CodecInfo {
+	return OfferCodecsWith(media.GlobalCodecs())
+}
+
 type MediaDesc struct {
 	Codecs         []CodecInfo
 	DTMFType       byte // set to 0 if there's no DTMF
@@ -106,11 +117,12 @@ func appendCryptoProfiles(attrs []sdp.Attribute, profiles []srtp.Profile) []sdp.
 	return attrs
 }
 
-func OfferMedia(rtpListenerPort int, encrypted Encryption) (MediaDesc, *sdp.MediaDescription, error) {
+// OfferMediaWith creates a new SDP media description with a given codec set, public IP address and listening port.
+func OfferMediaWith(s *media.CodecSet, rtpListenerPort int, encrypted Encryption) (MediaDesc, *sdp.MediaDescription, error) {
 	// Static compiler check for frame duration hardcoded below.
 	var _ = [1]struct{}{}[20*time.Millisecond-rtp.DefFrameDur]
 
-	codecs := OfferCodecs()
+	codecs := OfferCodecsWith(s)
 	attrs := make([]sdp.Attribute, 0, len(codecs)+4)
 	formats := make([]string, 0, len(codecs))
 	dtmfType := byte(0)
@@ -165,6 +177,14 @@ func OfferMedia(rtpListenerPort int, encrypted Encryption) (MediaDesc, *sdp.Medi
 		}, nil
 }
 
+// OfferMedia creates a new SDP media description.
+//
+// Deprecated: use OfferMediaWith
+func OfferMedia(rtpListenerPort int, encrypted Encryption) (MediaDesc, *sdp.MediaDescription, error) {
+	return OfferMediaWith(media.GlobalCodecs(), rtpListenerPort, encrypted)
+}
+
+// AnswerMedia creates a new SDP media description for an answer.
 func AnswerMedia(rtpListenerPort int, audio *AudioConfig, crypt *srtp.Profile) *sdp.MediaDescription {
 	// Static compiler check for frame duration hardcoded below.
 	var _ = [1]struct{}{}[20*time.Millisecond-rtp.DefFrameDur]
@@ -212,10 +232,11 @@ type Offer Description
 
 type Answer Description
 
-func NewOffer(publicIp netip.Addr, rtpListenerPort int, encrypted Encryption) (*Offer, error) {
+// NewOfferWith creates a new SDP offer with a given codec set, public IP address and listening port.
+func NewOfferWith(s *media.CodecSet, publicIp netip.Addr, rtpListenerPort int, encrypted Encryption) (*Offer, error) {
 	sessId := rand.Uint64() // TODO: do we need to track these?
 
-	m, mediaDesc, err := OfferMedia(rtpListenerPort, encrypted)
+	m, mediaDesc, err := OfferMediaWith(s, rtpListenerPort, encrypted)
 	if err != nil {
 		return nil, err
 	}
@@ -252,6 +273,14 @@ func NewOffer(publicIp netip.Addr, rtpListenerPort int, encrypted Encryption) (*
 	}, nil
 }
 
+// NewOffer creates a new SDP offer.
+//
+// Deprecated: use NewOfferWith
+func NewOffer(publicIp netip.Addr, rtpListenerPort int, encrypted Encryption) (*Offer, error) {
+	return NewOfferWith(media.GlobalCodecs(), publicIp, rtpListenerPort, encrypted)
+}
+
+// Answer generates an SDP answer for an offer.
 func (d *Offer) Answer(publicIp netip.Addr, rtpListenerPort int, enc Encryption) (*Answer, *MediaConfig, error) {
 	audio, err := SelectAudio(d.MediaDesc, false)
 	if err != nil {
@@ -321,6 +350,7 @@ func (d *Offer) Answer(publicIp netip.Addr, rtpListenerPort int, enc Encryption)
 		}, nil
 }
 
+// Apply the SDP offer to generate the final media config.
 func (d *Answer) Apply(offer *Offer, enc Encryption) (*MediaConfig, error) {
 	mc, _, err := d.apply(offer, enc, false)
 	return mc, err
@@ -396,7 +426,10 @@ func buildLocalSDP(sessionID uint64, local netip.AddrPort, audio *AudioConfig, s
 	return s, nil
 }
 
-func Parse(data []byte) (*Description, error) {
+// ParseWith parses the SDP description using the codecs from the codec set.
+//
+// This is a helper that is called by both ParseOfferWith and ParseAnswerWith.
+func ParseWith(s *media.CodecSet, data []byte) (*Description, error) {
 	offer := new(Description)
 	if err := offer.SDP.Unmarshal(data); err != nil {
 		return nil, err
@@ -412,7 +445,7 @@ func Parse(data []byte) (*Description, error) {
 	} else if !offer.Addr.IsValid() || offer.Addr.Port() == 0 {
 		return nil, fmt.Errorf("invalid audio address %q", offer.Addr)
 	}
-	m, err := ParseMedia(audio)
+	m, err := ParseMediaWith(s, audio)
 	if err != nil {
 		return nil, err
 	}
@@ -420,20 +453,44 @@ func Parse(data []byte) (*Description, error) {
 	return offer, nil
 }
 
-func ParseOffer(data []byte) (*Offer, error) {
-	d, err := Parse(data)
+// ParseOfferWith parses the SDP offer using the codecs from the codec set.
+func ParseOfferWith(s *media.CodecSet, data []byte) (*Offer, error) {
+	d, err := ParseWith(s, data)
 	if err != nil {
 		return nil, err
 	}
 	return (*Offer)(d), nil
 }
 
-func ParseAnswer(data []byte) (*Answer, error) {
-	d, err := Parse(data)
+// ParseAnswerWith parses the SDP answer using the codecs from the codec set.
+func ParseAnswerWith(s *media.CodecSet, data []byte) (*Answer, error) {
+	d, err := ParseWith(s, data)
 	if err != nil {
 		return nil, err
 	}
 	return (*Answer)(d), nil
+}
+
+// Parse the SDP description.
+// This is a helper that is called by both ParseOffer and ParseAnswer.
+//
+// Deprecated: use ParseWith
+func Parse(data []byte) (*Description, error) {
+	return ParseWith(media.NewCodecSet(), data)
+}
+
+// ParseOffer parses the SDP offer.
+//
+// Deprecated: use ParseOfferWith
+func ParseOffer(data []byte) (*Offer, error) {
+	return ParseOfferWith(media.NewCodecSet(), data)
+}
+
+// ParseAnswer parses the SDP answer.
+//
+// Deprecated: use ParseAnswerWith
+func ParseAnswer(data []byte) (*Answer, error) {
+	return ParseAnswerWith(media.NewCodecSet(), data)
 }
 
 // Returns valid lifetime, counted in packets encrypted using the associated key.
@@ -562,7 +619,8 @@ func parseSRTPProfile(val string) (*srtp.Profile, error) {
 	}, nil
 }
 
-func ParseMedia(d *sdp.MediaDescription) (*MediaDesc, error) {
+// ParseMediaWith parses SDP media description based on the given codec set.
+func ParseMediaWith(s *media.CodecSet, d *sdp.MediaDescription) (*MediaDesc, error) {
 	var out MediaDesc
 	for _, m := range d.Attributes {
 		switch m.Key {
@@ -580,7 +638,7 @@ func ParseMedia(d *sdp.MediaDescription) (*MediaDesc, error) {
 				out.DTMFType = byte(typ)
 				continue
 			}
-			codec, _ := CodecByName(name).(media.AudioCodec)
+			codec, _ := CodecByNameWith(s, name).(media.AudioCodec)
 			out.Codecs = append(out.Codecs, CodecInfo{
 				Type:  byte(typ),
 				Codec: codec,
@@ -601,7 +659,7 @@ func ParseMedia(d *sdp.MediaDescription) (*MediaDesc, error) {
 			continue
 		}
 		codec, _ := rtp.CodecByPayloadType(byte(typ)).(media.AudioCodec)
-		if !media.CodecEnabled(codec) {
+		if !s.IsEnabled(codec) {
 			codec = nil
 		}
 		out.Codecs = append(out.Codecs, CodecInfo{
@@ -610,6 +668,13 @@ func ParseMedia(d *sdp.MediaDescription) (*MediaDesc, error) {
 		})
 	}
 	return &out, nil
+}
+
+// ParseMedia parses SDP media description.
+//
+// Deprecated: use ParseMediaWith
+func ParseMedia(d *sdp.MediaDescription) (*MediaDesc, error) {
+	return ParseMediaWith(media.GlobalCodecs(), d)
 }
 
 // MediaConfig is the canonical representation of the negotiated session.

--- a/sdp/offer_test.go
+++ b/sdp/offer_test.go
@@ -45,8 +45,10 @@ func getInline(s string) string {
 }
 
 func TestSDPMediaOffer(t *testing.T) {
+	g := media.GlobalCodecs()
+
 	const port = 12345
-	_, offer, err := OfferMedia(port, EncryptionNone)
+	_, offer, err := OfferMediaWith(g, port, EncryptionNone)
 	require.NoError(t, err)
 	require.Equal(t, &sdp.MediaDescription{
 		MediaName: sdp.MediaName{
@@ -66,7 +68,7 @@ func TestSDPMediaOffer(t *testing.T) {
 		},
 	}, offer)
 
-	_, offer, err = OfferMedia(port, EncryptionRequire)
+	_, offer, err = OfferMediaWith(g, port, EncryptionRequire)
 	require.NoError(t, err)
 	i := slices.IndexFunc(offer.Attributes, func(a sdp.Attribute) bool {
 		return a.Key == "crypto"
@@ -94,10 +96,10 @@ func TestSDPMediaOffer(t *testing.T) {
 		},
 	}, offer)
 
-	media.CodecSetEnabled(g722.SDPName, false)
-	defer media.CodecSetEnabled(g722.SDPName, true)
+	noG722 := g.NewSet()
+	noG722.SetEnabled(g722.SDPName, false)
 
-	_, offer, err = OfferMedia(port, EncryptionNone)
+	_, offer, err = OfferMediaWith(noG722, port, EncryptionNone)
 	require.NoError(t, err)
 	require.Equal(t, &sdp.MediaDescription{
 		MediaName: sdp.MediaName{
@@ -117,11 +119,12 @@ func TestSDPMediaOffer(t *testing.T) {
 	}, offer)
 }
 
-func getCodec(name string) media.AudioCodec {
-	return CodecByName(name).(media.AudioCodec)
+func getCodec(s *media.CodecSet, name string) media.AudioCodec {
+	return CodecByNameWith(s, name).(media.AudioCodec)
 }
 
 func TestSDPMediaAnswer(t *testing.T) {
+	g := media.GlobalCodecs()
 	const port = 12345
 	cases := []struct {
 		name  string
@@ -141,7 +144,7 @@ func TestSDPMediaAnswer(t *testing.T) {
 				},
 			},
 			exp: &AudioConfig{
-				Codec:    getCodec(g722.SDPName),
+				Codec:    getCodec(g, g722.SDPName),
 				Type:     9,
 				DTMFType: 101,
 			},
@@ -159,7 +162,7 @@ func TestSDPMediaAnswer(t *testing.T) {
 				},
 			},
 			exp: &AudioConfig{
-				Codec:    getCodec(g722.SDPName),
+				Codec:    getCodec(g, g722.SDPName),
 				Type:     9,
 				DTMFType: 101,
 			},
@@ -176,7 +179,7 @@ func TestSDPMediaAnswer(t *testing.T) {
 				},
 			},
 			exp: &AudioConfig{
-				Codec: getCodec(g722.SDPName),
+				Codec: getCodec(g, g722.SDPName),
 				Type:  9,
 			},
 		},
@@ -193,7 +196,7 @@ func TestSDPMediaAnswer(t *testing.T) {
 				},
 			},
 			exp: &AudioConfig{
-				Codec:    getCodec(g722.SDPName),
+				Codec:    getCodec(g, g722.SDPName),
 				Type:     9,
 				DTMFType: 103,
 			},
@@ -210,7 +213,7 @@ func TestSDPMediaAnswer(t *testing.T) {
 				},
 			},
 			exp: &AudioConfig{
-				Codec:    getCodec(g711.ULawSDPName),
+				Codec:    getCodec(g, g711.ULawSDPName),
 				Type:     0,
 				DTMFType: 101,
 			},
@@ -227,7 +230,7 @@ func TestSDPMediaAnswer(t *testing.T) {
 				},
 			},
 			exp: &AudioConfig{
-				Codec:    getCodec(g722.SDPName),
+				Codec:    getCodec(g, g722.SDPName),
 				Type:     9,
 				DTMFType: 101,
 			},
@@ -256,7 +259,7 @@ func TestSDPMediaAnswer(t *testing.T) {
 				},
 			},
 			exp: &AudioConfig{
-				Codec:    getCodec(g711.ULawSDPName),
+				Codec:    getCodec(g, g711.ULawSDPName),
 				Type:     0,
 				DTMFType: 101,
 			},
@@ -270,7 +273,7 @@ func TestSDPMediaAnswer(t *testing.T) {
 				},
 			},
 			exp: &AudioConfig{
-				Codec:    getCodec(g711.ULawSDPName),
+				Codec:    getCodec(g, g711.ULawSDPName),
 				Type:     0,
 				DTMFType: 101,
 			},
@@ -287,7 +290,7 @@ func TestSDPMediaAnswer(t *testing.T) {
 				},
 			},
 			exp: &AudioConfig{
-				Codec: getCodec(g711.ULawSDPName),
+				Codec: getCodec(g, g711.ULawSDPName),
 				Type:  0,
 			},
 		},
@@ -303,7 +306,7 @@ func TestSDPMediaAnswer(t *testing.T) {
 				},
 			},
 			exp: &AudioConfig{
-				Codec: getCodec(g711.ALawSDPName),
+				Codec: getCodec(g, g711.ALawSDPName),
 				Type:  8,
 			},
 		},
@@ -311,7 +314,7 @@ func TestSDPMediaAnswer(t *testing.T) {
 	for _, c := range cases {
 		c := c
 		t.Run(c.name, func(t *testing.T) {
-			m, err := ParseMedia(&c.offer)
+			m, err := ParseMediaWith(g, &c.offer)
 			require.NoError(t, err)
 			got, err := SelectAudio(*m, true)
 			if c.exp == nil {
@@ -323,7 +326,7 @@ func TestSDPMediaAnswer(t *testing.T) {
 			require.Equal(t, c.exp, got)
 		})
 	}
-	_, offer, err := OfferMedia(port, EncryptionNone)
+	_, offer, err := OfferMediaWith(g, port, EncryptionNone)
 	require.NoError(t, err)
 	require.Equal(t, &sdp.MediaDescription{
 		MediaName: sdp.MediaName{
@@ -345,6 +348,8 @@ func TestSDPMediaAnswer(t *testing.T) {
 }
 
 func TestSDPMediaAnswerOneDisabled(t *testing.T) {
+	g := media.GlobalCodecs()
+
 	offer := sdp.MediaDescription{
 		MediaName: sdp.MediaName{
 			Formats: []string{"9", "0", "8", "101"},
@@ -356,15 +361,15 @@ func TestSDPMediaAnswerOneDisabled(t *testing.T) {
 		},
 	}
 	exp := &AudioConfig{
-		Codec:    getCodec(g711.ULawSDPName),
+		Codec:    getCodec(g, g711.ULawSDPName),
 		Type:     0,
 		DTMFType: 101,
 	}
 
-	media.CodecSetEnabled(g722.SDPName, false)
-	defer media.CodecSetEnabled(g722.SDPName, true)
+	noG722 := g.NewSet()
+	noG722.SetEnabled(g722.SDPName, false)
 
-	m, err := ParseMedia(&offer)
+	m, err := ParseMediaWith(noG722, &offer)
 	require.NoError(t, err)
 	got, err := SelectAudio(*m, false)
 	require.NoError(t, err)
@@ -373,6 +378,8 @@ func TestSDPMediaAnswerOneDisabled(t *testing.T) {
 }
 
 func TestSDPMediaAnswerAllDisabled(t *testing.T) {
+	g := media.GlobalCodecs()
+
 	offer := sdp.MediaDescription{
 		MediaName: sdp.MediaName{
 			Formats: []string{"9", "0", "101"},
@@ -384,12 +391,11 @@ func TestSDPMediaAnswerAllDisabled(t *testing.T) {
 		},
 	}
 
-	media.CodecSetEnabled(g722.SDPName, false)
-	defer media.CodecSetEnabled(g722.SDPName, true)
-	media.CodecSetEnabled(g711.ULawSDPName, false)
-	defer media.CodecSetEnabled(g711.ULawSDPName, true)
+	allOff := g.NewSet()
+	allOff.SetEnabled(g722.SDPName, false)
+	allOff.SetEnabled(g711.ULawSDPName, false)
 
-	m, err := ParseMedia(&offer)
+	m, err := ParseMediaWith(allOff, &offer)
 	require.NoError(t, err)
 	_, err = SelectAudio(*m, false)
 	require.Error(t, err)
@@ -397,6 +403,8 @@ func TestSDPMediaAnswerAllDisabled(t *testing.T) {
 }
 
 func TestParseOffer(t *testing.T) {
+	g := media.GlobalCodecs()
+
 	tests := []struct {
 		name    string
 		sdp     string
@@ -458,7 +466,7 @@ a=sendrecv
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := ParseOffer([]byte(test.sdp))
+			_, err := ParseOfferWith(g, []byte(test.sdp))
 			if test.wantErr {
 				require.Error(t, err)
 			} else {
@@ -469,6 +477,8 @@ a=sendrecv
 }
 
 func TestParseOfferSRTP(t *testing.T) {
+	g := media.GlobalCodecs()
+
 	vProfiles := []srtp.Profile{
 		{
 			Index:   1,
@@ -528,7 +538,7 @@ a=crypto:6 AEAD_AES_256_GCM inline:EFFzS2FMyNoYcVcaARU+nvk+JhHmVbvdFtRxZuRi9rDmL
 a=rtcp-fb:* trr-int 5000 
 a=rtcp-fb:* ccm tmmbr 
 `
-		v, err := ParseOffer([]byte(sdpData))
+		v, err := ParseOfferWith(g, []byte(sdpData))
 		require.NoError(t, err)
 		require.Equal(t, vProfiles, v.CryptoProfiles)
 	})
@@ -555,7 +565,7 @@ a=crypto:6 AEAD_AES_256_GCM inline:EFFzS2FMyNoYcVcaARU+nvk+JhHmVbvdFtRxZuRi9rDmL
 a=rtcp-fb:* trr-int 5000 
 a=rtcp-fb:* ccm tmmbr 
 `
-		v, err := ParseOffer([]byte(sdpData))
+		v, err := ParseOfferWith(g, []byte(sdpData))
 		require.NoError(t, err)
 		require.Equal(t, vProfiles, v.CryptoProfiles)
 	})
@@ -563,6 +573,8 @@ a=rtcp-fb:* ccm tmmbr
 
 // TestParseOfferLifetimeAndMKI verifies that lifetime and MKI are correctly parsed from an SDP offer
 func TestParseOfferLifetimeAndMKI(t *testing.T) {
+	g := media.GlobalCodecs()
+
 	// Create an SDP offer with lifetime and MKI in the crypto attribute
 	// Format: crypto:tag crypto-suite inline:base64-key-salt|lifetime|value:length
 	// lifetime: 2^48 (281474976710656)
@@ -580,7 +592,7 @@ a=ptime:20
 a=crypto:1 AES_CM_128_HMAC_SHA1_80 inline:pMIPxjzYIG5TQuIWfkjTnaACVrzohhFfOGhSMgV1|2^48|66051:4 
 `
 
-	offer, err := ParseOffer([]byte(sdpData))
+	offer, err := ParseOfferWith(g, []byte(sdpData))
 	require.NoError(t, err)
 	require.NotEmpty(t, offer.CryptoProfiles)
 
@@ -685,12 +697,14 @@ func extractMKIFromSRTPPacket(packet []byte, mkiLength int, authTagSize int) []b
 
 // Test actually using the MKI in an offer with outgoing RTP packets
 func TestSRTPIntegration(t *testing.T) {
+	g := media.GlobalCodecs()
+
 	log := logger.GetLogger()
 	stop := make(chan struct{})
 	defer close(stop)
 
 	// Generate offer
-	offer, err := NewOffer(netip.MustParseAddr("127.0.0.1"), 5000, EncryptionRequire)
+	offer, err := NewOfferWith(g, netip.MustParseAddr("127.0.0.1"), 5000, EncryptionRequire)
 	require.NoError(t, err)
 	require.NotEmpty(t, offer.CryptoProfiles)
 


### PR DESCRIPTION
Preparations for allowing custom codec setup on SIP trunks. Introduce `CodecSet` that can overlay a parent set. This will allow us to set defaults with most common codecs, while allowing each trunk to have it's own config with more exotic codecs.

This is a must-have for introducing new codecs like AMR-WB, G729, etc. Without this, our default SDP will get pretty large.