### PR TITLE
fix(dtmf): nil events guard for ResetTimestamp

### DIFF
--- a/dtmf/dtmf.go
+++ b/dtmf/dtmf.go
@@ -238,7 +238,9 @@ func Write(ctx context.Context, audio media.Writer[media.PCM16Sample], events *r
 		}
 	}
 
-	events.ResetTimestamp(startTs)
+	if events != nil {
+		events.ResetTimestamp(startTs)
+	}
 
 	for {
 		select {


### PR DESCRIPTION
Implementing in-band DTMF where events is nil, only this method call wasn't guarded by a nil check