### PR TITLE
Add package that registers all supported codecs.

### DIFF
--- a/all/all.go
+++ b/all/all.go
@@ -1,0 +1,8 @@
+package all
+
+// Register all supported pure-Go codecs. CGo codecs must be in all_cgo.go.
+import (
+	_ "github.com/livekit/media-sdk/dtmf"
+	_ "github.com/livekit/media-sdk/g711"
+	_ "github.com/livekit/media-sdk/g722"
+)

--- a/all/all_cgo.go
+++ b/all/all_cgo.go
@@ -1,0 +1,8 @@
+//go:build cgo
+
+package all
+
+// Register all supported codecs that use CGo.
+import (
+	_ "github.com/livekit/media-sdk/opus"
+)


### PR DESCRIPTION
This will help SIP automatically pick up new codecs that are supported by the media SDK.