### PR TITLE
Allow selecting Go resampler with predictable output.

### DIFF
--- a/resample.go
+++ b/resample.go
@@ -25,31 +25,80 @@ var (
 	resampleDumpToFile = os.Getenv("LK_DUMP_RESAMPLE") == "true"
 )
 
+var DefaultResampleOptions []ResampleOption
+
 // Resample the source sample into the destination sample rate.
 // It appends resulting samples to dst and returns the result.
-func Resample(dst PCM16Sample, dstSampleRate int, src PCM16Sample, srcSampleRate int) PCM16Sample {
+func Resample(dst PCM16Sample, dstSampleRate int, src PCM16Sample, srcSampleRate int, opts ...ResampleOption) PCM16Sample {
 	if dstSampleRate == srcSampleRate {
 		return append(dst, src...)
 	}
-	return resampleBuffer(dst, dstSampleRate, src, srcSampleRate)
+	if len(opts) == 0 {
+		opts = DefaultResampleOptions
+	}
+	var opt resampleOptions
+	for _, o := range opts {
+		o(&opt)
+	}
+	if opt.Predictable {
+		return resampleBufferBeep(dst, dstSampleRate, src, srcSampleRate, &opt)
+	}
+	return resampleBuffer(dst, dstSampleRate, src, srcSampleRate, &opt)
+}
+
+type ResampleOption func(opts *resampleOptions)
+
+func WithPredictableResample(enable bool) ResampleOption {
+	return func(opts *resampleOptions) {
+		opts.Predictable = enable
+	}
+}
+
+func WithResampleDump(inputName, outputName string) ResampleOption {
+	return func(opts *resampleOptions) {
+		opts.DumpInput = inputName
+		opts.DumpOutput = outputName
+	}
+}
+
+type resampleOptions struct {
+	Predictable bool
+	DumpInput   string
+	DumpOutput  string
 }
 
 // ResampleWriter returns a new writer that expects samples of a given sample rate
 // and resamples then for the destination writer.
-func ResampleWriter(w PCM16Writer, sampleRate int) (w2 PCM16Writer) {
+func ResampleWriter(w PCM16Writer, sampleRate int, opts ...ResampleOption) (w2 PCM16Writer) {
 	srcRate := sampleRate
 	dstRate := w.SampleRate()
 	if dstRate == srcRate {
 		return w
 	}
+	if len(opts) == 0 {
+		opts = DefaultResampleOptions
+	}
+	var opt resampleOptions
+	for _, o := range opts {
+		o(&opt)
+	}
 
 	if resampleDumpToFile {
 		id := resampleID.Add(1)
 		pref := fmt.Sprintf("sip_resample_%d", id)
-		w = DumpWriterPCM16(pref+"_out", w)
+		opt.DumpInput = pref + "_in"
+		opt.DumpOutput = pref + "_out"
+	}
+	if file := opt.DumpOutput; file != "" {
+		w = DumpWriterPCM16(file, w)
+	}
+	if file := opt.DumpInput; file != "" {
 		defer func() {
-			w2 = DumpWriterPCM16(pref+"_in", w2)
+			w2 = DumpWriterPCM16(file, w2)
 		}()
 	}
-	return newResampleWriter(w, sampleRate)
+	if opt.Predictable {
+		return newResampleWriterBeep(w, sampleRate, &opt)
+	}
+	return newResampleWriter(w, sampleRate, &opt)
 }

--- a/resample_beep.go
+++ b/resample_beep.go
@@ -1,5 +1,3 @@
-//go:build !cgo
-
 // Copyright 2024 LiveKit, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,10 +14,12 @@
 
 package media
 
-const quality = 3
+import "fmt"
 
-func resampleBuffer(dst PCM16Sample, dstSampleRate int, src PCM16Sample, srcSampleRate int) PCM16Sample {
-	r := beepResample(quality, srcSampleRate, dstSampleRate, NewPCM16BufferReader(src))
+const beepQuality = 3
+
+func resampleBufferBeep(dst PCM16Sample, dstSampleRate int, src PCM16Sample, srcSampleRate int, opts *resampleOptions) PCM16Sample {
+	r := beepResample(beepQuality, srcSampleRate, dstSampleRate, NewPCM16BufferReader(src))
 	sz := 0
 	if dstSampleRate < srcSampleRate {
 		div := srcSampleRate / dstSampleRate
@@ -33,19 +33,19 @@ func resampleBuffer(dst PCM16Sample, dstSampleRate int, src PCM16Sample, srcSamp
 	return append(dst, out[:n]...)
 }
 
-func newResampleWriter(w WriteCloser[PCM16Sample], sampleRate int) WriteCloser[PCM16Sample] {
+func newResampleWriterBeep(w WriteCloser[PCM16Sample], sampleRate int, opts *resampleOptions) WriteCloser[PCM16Sample] {
 	srcRate := sampleRate
 	dstRate := w.SampleRate()
-	r := &resampleWriter{
+	r := &resampleWriterBeep{
 		w:       w,
 		srcRate: srcRate,
 		dstRate: dstRate,
 	}
-	r.r = beepResample(quality, srcRate, dstRate, r)
+	r.r = beepResample(beepQuality, srcRate, dstRate, r)
 	return r
 }
 
-type resampleWriter struct {
+type resampleWriterBeep struct {
 	w       WriteCloser[PCM16Sample]
 	r       *beepResampler
 	inbuf   PCM16Sample
@@ -54,21 +54,25 @@ type resampleWriter struct {
 	buf     PCM16Sample
 }
 
-func (w *resampleWriter) SampleRate() int {
+func (w *resampleWriterBeep) String() string {
+	return fmt.Sprintf("Resample(%d->%d) -> %s", w.srcRate, w.dstRate, w.w.String())
+}
+
+func (w *resampleWriterBeep) SampleRate() int {
 	return w.srcRate
 }
 
-func (w *resampleWriter) Close() error {
+func (w *resampleWriterBeep) Close() error {
 	return w.w.Close()
 }
 
-func (w *resampleWriter) ReadSample(data PCM16Sample) (int, error) {
+func (w *resampleWriterBeep) ReadSample(data PCM16Sample) (int, error) {
 	n := copy(data, w.inbuf)
 	w.inbuf = w.inbuf[n:]
 	return n, nil
 }
 
-func (w *resampleWriter) WriteSample(data PCM16Sample) error {
+func (w *resampleWriterBeep) WriteSample(data PCM16Sample) error {
 	w.inbuf = append(w.inbuf, data...)
 	var sz int
 	if w.srcRate > w.dstRate {

--- a/resample_nocgo.go
+++ b/resample_nocgo.go
@@ -1,0 +1,11 @@
+//go:build !cgo
+
+package media
+
+func resampleBuffer(dst PCM16Sample, dstSampleRate int, src PCM16Sample, srcSampleRate int, opts *resampleOptions) PCM16Sample {
+	return resampleBufferBeep(dst, dstSampleRate, src, srcSampleRate, opts)
+}
+
+func newResampleWriter(w WriteCloser[PCM16Sample], sampleRate int, opts *resampleOptions) WriteCloser[PCM16Sample] {
+	return newResampleWriterBeep(w, sampleRate, opts)
+}

--- a/resample_soxr.go
+++ b/resample_soxr.go
@@ -44,8 +44,8 @@ func resampleSize(dstSampleRate, srcSampleRate int, srcSize int) int {
 	return sz
 }
 
-func resampleBuffer(dst PCM16Sample, dstSampleRate int, src PCM16Sample, srcSampleRate int) PCM16Sample {
-	w := newResampleWriter(NewPCM16BufferWriter(&dst, dstSampleRate), srcSampleRate)
+func resampleBuffer(dst PCM16Sample, dstSampleRate int, src PCM16Sample, srcSampleRate int, opts *resampleOptions) PCM16Sample {
+	w := newResampleWriter(NewPCM16BufferWriter(&dst, dstSampleRate), srcSampleRate, opts)
 	err := w.WriteSample(src)
 	_ = w.Close()
 	if err != nil {
@@ -54,7 +54,7 @@ func resampleBuffer(dst PCM16Sample, dstSampleRate int, src PCM16Sample, srcSamp
 	return dst
 }
 
-func newResampleWriter(w WriteCloser[PCM16Sample], sampleRate int) WriteCloser[PCM16Sample] {
+func newResampleWriter(w WriteCloser[PCM16Sample], sampleRate int, opts *resampleOptions) WriteCloser[PCM16Sample] {
 	srcRate := sampleRate
 	dstRate := w.SampleRate()
 	r := &resampleWriter{
@@ -188,6 +188,7 @@ func newSoxr(dstRate, srcRate int, quality int) (*soxrResampler, error) {
 	if err != nil {
 		return nil, err
 	}
+	// p.seed = 1234567890 // TODO: set seed somehow, otherwise results are random
 	// This variable helps avoid double-free on the soxr resampler ptr. See soxrCleanup.
 	done := new(atomic.Bool)
 	r := &soxrResampler{

--- a/resampler_beep.go
+++ b/resampler_beep.go
@@ -1,5 +1,3 @@
-//go:build !cgo
-
 // MIT License
 //
 // Copyright (c) 2017 Michal Štrba


### PR DESCRIPTION
The main C resampler that we use (soxr) has builtin randomness that we cannot directly control. This causes flaky tests and unpredictable (although tiny) output delay.

This PR adds an option to enable Go-based resampler. For now we'll only enable it in tests.