### PR TITLE
feat(sdp): mirror media direction in answer

### DIFF
--- a/sdp/offer.go
+++ b/sdp/offer.go
@@ -119,7 +119,7 @@ func appendCryptoProfiles(attrs []sdp.Attribute, profiles []srtp.Profile) []sdp.
 }
 
 // OfferMediaWith creates a new SDP media description with a given codec set, public IP address and listening port.
-func OfferMediaWith(s *media.CodecSet, rtpListenerPort int, encrypted Encryption) (MediaDesc, *sdp.MediaDescription, error) {
+func OfferMediaWith(s *media.CodecSet, rtpListenerPort int, encrypted Encryption, dir sdp.Direction) (MediaDesc, *sdp.MediaDescription, error) {
 	// Static compiler check for frame duration hardcoded below.
 	var _ = [1]struct{}{}[20*time.Millisecond-rtp.DefFrameDur]
 
@@ -153,9 +153,12 @@ func OfferMediaWith(s *media.CodecSet, rtpListenerPort int, encrypted Encryption
 		attrs = appendCryptoProfiles(attrs, cryptoProfiles)
 	}
 
+	if dir == 0 {
+		dir = sdp.DirectionSendRecv
+	}
 	attrs = append(attrs, []sdp.Attribute{
 		{Key: "ptime", Value: "20"},
-		{Key: "sendrecv"},
+		{Key: dir.String()},
 	}...)
 
 	proto := "AVP"
@@ -182,7 +185,7 @@ func OfferMediaWith(s *media.CodecSet, rtpListenerPort int, encrypted Encryption
 //
 // Deprecated: use OfferMediaWith
 func OfferMedia(rtpListenerPort int, encrypted Encryption) (MediaDesc, *sdp.MediaDescription, error) {
-	return OfferMediaWith(media.GlobalCodecs(), rtpListenerPort, encrypted)
+	return OfferMediaWith(media.GlobalCodecs(), rtpListenerPort, encrypted, sdp.DirectionSendRecv)
 }
 
 // AnswerMedia creates a new SDP media description for an answer.
@@ -207,6 +210,9 @@ func AnswerMedia(rtpListenerPort int, audio *AudioConfig, crypt *srtp.Profile, d
 	if crypt != nil {
 		proto = "SAVP"
 		attrs = appendCryptoProfiles(attrs, []srtp.Profile{*crypt})
+	}
+	if dir == 0 {
+		dir = sdp.DirectionSendRecv
 	}
 	attrs = append(attrs, []sdp.Attribute{
 		{Key: "ptime", Value: "20"},
@@ -252,7 +258,7 @@ type Answer Description
 func NewOfferWith(s *media.CodecSet, publicIp netip.Addr, rtpListenerPort int, encrypted Encryption) (*Offer, error) {
 	sessId := rand.Uint64() // TODO: do we need to track these?
 
-	m, mediaDesc, err := OfferMediaWith(s, rtpListenerPort, encrypted)
+	m, mediaDesc, err := OfferMediaWith(s, rtpListenerPort, encrypted, sdp.DirectionSendRecv)
 	if err != nil {
 		return nil, err
 	}

--- a/sdp/offer.go
+++ b/sdp/offer.go
@@ -186,7 +186,7 @@ func OfferMedia(rtpListenerPort int, encrypted Encryption) (MediaDesc, *sdp.Medi
 }
 
 // AnswerMedia creates a new SDP media description for an answer.
-func AnswerMedia(rtpListenerPort int, audio *AudioConfig, crypt *srtp.Profile) *sdp.MediaDescription {
+func AnswerMedia(rtpListenerPort int, audio *AudioConfig, crypt *srtp.Profile, dir sdp.Direction) *sdp.MediaDescription {
 	// Static compiler check for frame duration hardcoded below.
 	var _ = [1]struct{}{}[20*time.Millisecond-rtp.DefFrameDur]
 
@@ -210,7 +210,7 @@ func AnswerMedia(rtpListenerPort int, audio *AudioConfig, crypt *srtp.Profile) *
 	}
 	attrs = append(attrs, []sdp.Attribute{
 		{Key: "ptime", Value: "20"},
-		{Key: "sendrecv"},
+		{Key: dir.String()},
 	}...)
 	return &sdp.MediaDescription{
 		MediaName: sdp.MediaName{
@@ -220,6 +220,21 @@ func AnswerMedia(rtpListenerPort int, audio *AudioConfig, crypt *srtp.Profile) *
 			Formats: formats,
 		},
 		Attributes: attrs,
+	}
+}
+
+func mirror(d sdp.Direction) sdp.Direction {
+	switch d {
+	case sdp.DirectionSendRecv:
+		return sdp.DirectionSendRecv
+	case sdp.DirectionSendOnly:
+		return sdp.DirectionRecvOnly
+	case sdp.DirectionRecvOnly:
+		return sdp.DirectionSendOnly
+	case sdp.DirectionInactive:
+		return sdp.DirectionInactive
+	default:
+		return sdp.DirectionSendRecv
 	}
 }
 
@@ -306,7 +321,8 @@ func (d *Offer) Answer(publicIp netip.Addr, rtpListenerPort int, enc Encryption)
 		return nil, nil, ErrNoCommonCrypto
 	}
 
-	mediaDesc := AnswerMedia(rtpListenerPort, audio, sprof)
+	dir := mirror(d.MediaDesc.Direction)
+	mediaDesc := AnswerMedia(rtpListenerPort, audio, sprof, dir)
 	answer := sdp.SessionDescription{
 		Version: 0,
 		Origin: sdp.Origin{
@@ -402,7 +418,7 @@ func buildLocalSDP(sessionID uint64, local netip.AddrPort, audio *AudioConfig, s
 	}
 	addrStr := local.Addr().String()
 	portVal := int(local.Port())
-	mediaDesc := AnswerMedia(portVal, audio, sprof)
+	mediaDesc := AnswerMedia(portVal, audio, sprof, sdp.DirectionSendRecv)
 	s := &sdp.SessionDescription{
 		Version: 0,
 		Origin: sdp.Origin{

--- a/sdp/offer_test.go
+++ b/sdp/offer_test.go
@@ -879,3 +879,51 @@ a=inactive
 		})
 	}
 }
+
+func TestAnswerMirrorsDirection(t *testing.T) {
+	g := media.GlobalCodecs()
+
+	const offer = `v=0
+o=- 1 1 IN IP4 203.0.113.5
+s=LiveKit
+c=IN IP4 203.0.113.5
+t=0 0
+m=audio 10000 RTP/AVP 0
+a=rtpmap:0 PCMU/8000
+`
+
+	tests := []struct {
+		name string
+		dir  string        // direction in the offer
+		want sdp.Direction // expected mirrored direction in the answer
+	}{
+		{name: "sendonly mirrors to recvonly", dir: "a=sendonly\n", want: sdp.DirectionRecvOnly},
+		{name: "recvonly mirrors to sendonly", dir: "a=recvonly\n", want: sdp.DirectionSendOnly},
+		{name: "inactive stays inactive", dir: "a=inactive\n", want: sdp.DirectionInactive},
+		{name: "sendrecv stays sendrecv", dir: "a=sendrecv\n", want: sdp.DirectionSendRecv},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			o, err := ParseOfferWith(g, []byte(offer+test.dir))
+			require.NoError(t, err)
+
+			answer, _, err := o.Answer(netip.MustParseAddr("203.0.113.9"), 20000, EncryptionNone)
+			require.NoError(t, err)
+			
+			require.Equal(t, test.want, answerDirection(t, answer.SDP.MediaDescriptions[0]))
+		})
+	}
+}
+
+// answerDirection returns the direction attribute set on a media description.
+func answerDirection(t *testing.T, m *sdp.MediaDescription) sdp.Direction {
+	t.Helper()
+	for _, a := range m.Attributes {
+		if dir, err := sdp.NewDirection(a.Key); err == nil {
+			return dir
+		}
+	}
+	t.Fatal("no direction attribute in answer")
+	return 0
+}

--- a/sdp/offer_test.go
+++ b/sdp/offer_test.go
@@ -48,7 +48,7 @@ func TestSDPMediaOffer(t *testing.T) {
 	g := media.GlobalCodecs()
 
 	const port = 12345
-	_, offer, err := OfferMediaWith(g, port, EncryptionNone)
+	_, offer, err := OfferMediaWith(g, port, EncryptionNone, 0)
 	require.NoError(t, err)
 	require.Equal(t, &sdp.MediaDescription{
 		MediaName: sdp.MediaName{
@@ -68,7 +68,7 @@ func TestSDPMediaOffer(t *testing.T) {
 		},
 	}, offer)
 
-	_, offer, err = OfferMediaWith(g, port, EncryptionRequire)
+	_, offer, err = OfferMediaWith(g, port, EncryptionRequire, 0)
 	require.NoError(t, err)
 	i := slices.IndexFunc(offer.Attributes, func(a sdp.Attribute) bool {
 		return a.Key == "crypto"
@@ -99,7 +99,7 @@ func TestSDPMediaOffer(t *testing.T) {
 	noG722 := g.NewSet()
 	noG722.SetEnabled(g722.SDPNameAndRate, false)
 
-	_, offer, err = OfferMediaWith(noG722, port, EncryptionNone)
+	_, offer, err = OfferMediaWith(noG722, port, EncryptionNone, 0)
 	require.NoError(t, err)
 	require.Equal(t, &sdp.MediaDescription{
 		MediaName: sdp.MediaName{
@@ -326,7 +326,7 @@ func TestSDPMediaAnswer(t *testing.T) {
 			require.Equal(t, c.exp, got)
 		})
 	}
-	_, offer, err := OfferMediaWith(g, port, EncryptionNone)
+	_, offer, err := OfferMediaWith(g, port, EncryptionNone, 0)
 	require.NoError(t, err)
 	require.Equal(t, &sdp.MediaDescription{
 		MediaName: sdp.MediaName{


### PR DESCRIPTION
Generate the answer's direction by mirroring the offer per RFC 3264 §6.1
(sendonly↔recvonly, sendrecv/inactive unchanged) instead of always emitting
sendrecv. AnswerMedia now takes the direction as a parameter.

Added a table-driven test in offer_test.go covering all four directions
through Offer.Answer.

Follow-up to #67. Related to [issue](https://github.com/livekit/sip/issues/716)