### PR TITLE
Add bounds check before indexing into keys buffer.

### DIFF
--- a/sdp/offer.go
+++ b/sdp/offer.go
@@ -625,6 +625,9 @@ func parseSRTPProfile(val string) (*srtp.Profile, error) {
 		if err != nil {
 			return nil, err
 		}
+		if keyLen > len(keys) {
+			return nil, fmt.Errorf("parsed key length is greater than key buffer size: keyLen: %d; len(keys): %d", keyLen, len(keys))
+		}
 		keys, salt = keys[:keyLen], keys[keyLen:]
 	}
 	return &srtp.Profile{


### PR DESCRIPTION
This line is causing some of the cloud-sip instances to panic. I haven't yet root caused why this line just started panicking now.