### PR TITLE
ci: fix the Go build cache never being hit

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,13 +26,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/go/bin
-            ~/.cache
-          key: media-sdk
 
       - name: Set up SoX resampler and Opus
         run: |
@@ -43,6 +36,23 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: 1.26
+          # setup-go's own cache restores on an exact key only, so any go.sum
+          # change is a full cold build. Restored below instead.
+          cache: false
+
+      # The run_id suffix never pre-exists, so a push always writes a fresh
+      # entry rather than one frozen at the go.sum that first created it.
+      - name: Restore Go caches
+        id: go-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: go-${{ runner.os }}-${{ hashFiles('go.sum') }}-${{ github.run_id }}
+          restore-keys: |
+            go-${{ runner.os }}-${{ hashFiles('go.sum') }}-
+            go-${{ runner.os }}-
 
       - name: Set up gotestfmt
         run: go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
@@ -67,3 +77,14 @@ jobs:
         run: |
           set -euo pipefail
           go test -json -v ./... 2>&1 | gotestfmt
+
+      # Only main writes. Pull requests read main's entry, which keeps ~1 GB
+      # per PR run out of the repo's 10 GB cache budget.
+      - name: Save Go caches
+        if: github.event_name == 'push'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ steps.go-cache.outputs.cache-primary-key }}


### PR DESCRIPTION
The `Test` job compiles the module from scratch on every run, because neither of the two caches configured here has ever produced a hit.

**The `actions/cache` step used a constant key.** `key: media-sdk` never changes, and `actions/cache` does not re-save on a hit, so the entry stayed frozen at whatever it held when first written. The cache API reports it as **227 MB, created 2026-08-06**, still being restored today — and because every run reads it, its last-accessed time keeps refreshing, so it never ages out either. Nothing in it could match: it cached all of `~/.cache`, whose `go-build` entries are keyed by compiler build ID, so a newer toolchain misses every one. It cost time on every run and left a `GOCACHE` full of dead entries that `setup-go` then re-uploaded.

**setup-go's built-in cache cannot close the gap.** Its key is `setup-go-{os}-{arch}-{linuxver}go-{version}-{go.sum hash}`, and it calls `restoreCache` with no restore keys — a match is exact or nothing, and upstream has declined to add prefix fallback ([actions/setup-go#404](https://github.com/actions/setup-go/issues/404)). So any dependency bump rebuilds everything rather than just the part that changed, and a Go point release rotates the key out from under every open PR at once.

## What this changes

- Drops the dead `actions/cache` step.
- Sets `cache: false` on setup-go and restores via `actions/cache/restore`, keyed on the `go.sum` hash with a prefix fallback, so a dependency change reuses the entries that are still valid.
- Suffixes the key with `run_id` so it never matches on write. A push therefore always stores a fresh entry, rather than one pinned to the `go.sum` that first created it.
- Limits saving to pushes. Pull requests read main's entry and write nothing, which keeps roughly a gigabyte per PR run out of the repo's 10 GB budget.

Narrowing the paths to `~/.cache/go-build` and `~/go/pkg/mod` drops `~/go/bin`. Binaries installed there are re-`go install`ed on every run regardless, and the build cache covers most of that cost.

The save step reuses the restore step's `cache-primary-key` output rather than re-evaluating `hashFiles`, because the `Replace mutexes` step rewrites `go.mod`/`go.sum` partway through the job. The key therefore reflects the committed `go.sum`, not the mutated one.

## Follow-up, not in this PR

The frozen 227 MB `media-sdk` entry this PR stops writing to should be deleted; nothing will read it again.
