### PR TITLE
Fix race in rtp.Session.

### DIFF
--- a/rtp/session.go
+++ b/rtp/session.go
@@ -28,8 +28,7 @@ import (
 )
 
 const (
-	enableZeroCopy = true
-	MTUSize        = 1500
+	MTUSize = 1500
 )
 
 type Session interface {
@@ -168,40 +167,51 @@ type readStream struct {
 }
 
 func (r *readStream) write(p *rtp.Packet) {
-	if enableZeroCopy {
-		r.mu.Lock()
-		h, payload := r.hdr, r.payload
+	r.mu.Lock()
+
+	if r.hdr != nil {
+		// zero copy
+		*r.hdr = p.Header
+		n := copy(r.payload, p.Payload)
 		r.hdr, r.payload = nil, nil
 		r.mu.Unlock()
-		if h != nil {
-			// zero copy
-			*h = p.Header
-			n := copy(payload, p.Payload)
-			select {
-			case <-r.closed:
-			case r.copied <- n:
-			}
-			return
+
+		select {
+		case <-r.closed:
+		case r.copied <- n:
 		}
+		return
 	}
 	p.Payload = slices.Clone(p.Payload)
 	select {
 	case r.recv <- p:
 	default:
 	}
+	r.mu.Unlock()
 }
 
 func (r *readStream) ReadRTP(h *rtp.Header, payload []byte) (int, error) {
 	direct := false
-	if enableZeroCopy {
-		r.mu.Lock()
-		if r.hdr == nil {
-			r.hdr = h
-			r.payload = payload
-			direct = true
-		}
+	r.mu.Lock()
+
+	// Check the queue before offering our buffer.
+	select {
+	case p := <-r.recv:
 		r.mu.Unlock()
+		*h = p.Header
+		n := copy(payload, p.Payload)
+		return n, nil
+	default:
 	}
+
+	if r.hdr == nil {
+		r.hdr = h
+		r.payload = payload
+		direct = true
+	}
+	r.mu.Unlock()
+
+	// If we didn't successfully make an offer, read from the queue.
 	if !direct {
 		select {
 		case p := <-r.recv:
@@ -212,6 +222,7 @@ func (r *readStream) ReadRTP(h *rtp.Header, payload []byte) (int, error) {
 		}
 		return 0, io.EOF
 	}
+
 	defer func() {
 		r.mu.Lock()
 		defer r.mu.Unlock()
@@ -219,12 +230,10 @@ func (r *readStream) ReadRTP(h *rtp.Header, payload []byte) (int, error) {
 			r.hdr, r.payload = nil, nil
 		}
 	}()
+
+	// If we were able to offer our buffer, wait for the copy signal.
 	select {
 	case n := <-r.copied:
-		return n, nil
-	case p := <-r.recv:
-		*h = p.Header
-		n := copy(payload, p.Payload)
 		return n, nil
 	case <-r.closed:
 	}

--- a/rtp/session_test.go
+++ b/rtp/session_test.go
@@ -62,9 +62,6 @@ func payloadForSequenceNumber(sequenceNumber int) []byte {
 	return payload
 }
 
-// payloadIndex recovers the packet index from a payload built by indexPayload, or -1 if
-// the payload is not a single repeated index - meaning bytes from two different packets
-// were interleaved into the buffer.
 func sequenceNumberFromPayload(payload []byte) int {
 	if len(payload) < 2 || len(payload)%2 != 0 {
 		return -1
@@ -78,40 +75,33 @@ func verifyRTPPacket(h *rtp.Header, payload []byte) error {
 		return fmt.Errorf("header never written: ReadRTP reported %d bytes carrying packet %d, but left the header zeroed",
 			len(payload), sequenceNumberFromPayload(payload))
 	}
+
 	if h.Version != 2 || h.PayloadType != testPayloadType || h.SSRC != testStreamSSRC {
 		return fmt.Errorf("torn header: got version=%d pt=%d ssrc=%#x, want version=2 pt=%d ssrc=%#x (seq=%d ts=%d)",
 			h.Version, h.PayloadType, h.SSRC, testPayloadType, uint32(testStreamSSRC), h.SequenceNumber, h.Timestamp)
 	}
+
 	sequenceNumber := int(h.SequenceNumber)
 	if exp := uint32(sequenceNumber) * testClockPerPkt; h.Timestamp != exp {
 		return fmt.Errorf("torn header: seq=%d implies ts=%d, got ts=%d - header fields came from two packets",
 			sequenceNumber, exp, h.Timestamp)
 	}
+
 	if len(payload) != testPayloadSize {
 		return fmt.Errorf("unexpected payload length: header says seq=%d, but ReadRTP returned %d payload bytes, want %d",
 			sequenceNumber, len(payload), testPayloadSize)
 	}
-	switch got := sequenceNumberFromPayload(payload); got {
-	case sequenceNumber:
-		return nil
-	default:
+
+	gotSequeneceNumber := sequenceNumberFromPayload(payload)
+	if gotSequeneceNumber != sequenceNumber {
 		return fmt.Errorf("mixed payload: header says seq=%d, but the buffer holds packet %d",
-			sequenceNumber, got)
+			sequenceNumber, gotSequeneceNumber)
 	}
+	return nil
 }
 
 func TestSessionZeroCopyHandoff(t *testing.T) {
-	// Deliberately not gated on enableZeroCopy: "every delivered packet is internally
-	// consistent" must hold on both delivery paths, so this test is also the check that
-	// compiling the handoff out is a safe mitigation.
-	for i := range 10 {
-		t.Run(fmt.Sprint(i), func(t *testing.T) {
-			testZeroCopyHandoff(t, 8000)
-		})
-	}
-}
-
-func testZeroCopyHandoff(t *testing.T, packets int) {
+	numPackets := 8000
 	cli, srv := net.Pipe()
 	defer cli.Close()
 	require.NoError(t, srv.SetReadDeadline(time.Now().Add(30*time.Second)))
@@ -119,12 +109,8 @@ func testZeroCopyHandoff(t *testing.T, packets int) {
 	sess := NewSession(logger.GetLogger(), srv)
 	defer sess.Close()
 
-	// TODO(alexfish): Clean this up.
-
-	// Blast one SSRC with no pacing, so the pump delivers packets microseconds apart
-	// rather than a frame apart, then a sentinel SSRC to mark the end of the run.
-	sent := make([][]byte, 0, packets+1)
-	for i := range packets {
+	sent := make([][]byte, 0, numPackets+1)
+	for i := range numPackets {
 		sent = append(sent, newRTPPacket(t, testStreamSSRC, i))
 	}
 	sent = append(sent, newRTPPacket(t, testSentinelSSRC, 0))
@@ -138,8 +124,6 @@ func testZeroCopyHandoff(t *testing.T, packets int) {
 		}
 	})
 
-	// The first AcceptStream returns the stream for testStreamSSRC. Its first packet is
-	// already sitting in r.recv - AcceptStream calls r.write before it returns.
 	r, ssrc, err := sess.AcceptStream()
 	require.NoError(t, err)
 	require.EqualValues(t, uint32(testStreamSSRC), ssrc)
@@ -181,5 +165,5 @@ func testZeroCopyHandoff(t *testing.T, packets int) {
 
 	require.NoError(t, verifyErr, "ReadRTP delivered a corrupted packet")
 	require.NotZero(t, delivered, "no packets were delivered")
-	t.Logf("delivered %d/%d packets", delivered, packets)
+	t.Logf("delivered %d/%d packets", delivered, numPackets)
 }

--- a/rtp/session_test.go
+++ b/rtp/session_test.go
@@ -47,14 +47,14 @@ func newRTPPacket(t *testing.T, ssrc uint32, sequenceNumber int) []byte {
 			Timestamp:      uint32(sequenceNumber) * testClockPerPkt,
 			SSRC:           ssrc,
 		},
-		Payload: indexPayload(sequenceNumber),
+		Payload: payloadForSequenceNumber(sequenceNumber),
 	}
 	buf, err := p.Marshal()
 	require.NoError(t, err)
 	return buf
 }
 
-func indexPayload(sequenceNumber int) []byte {
+func payloadForSequenceNumber(sequenceNumber int) []byte {
 	payload := make([]byte, testPayloadSize)
 	for off := 0; off < len(payload); off += 2 {
 		binary.BigEndian.PutUint16(payload[off:], uint16(sequenceNumber))
@@ -65,27 +65,18 @@ func indexPayload(sequenceNumber int) []byte {
 // payloadIndex recovers the packet index from a payload built by indexPayload, or -1 if
 // the payload is not a single repeated index - meaning bytes from two different packets
 // were interleaved into the buffer.
-func payloadIndex(payload []byte) int {
+func sequenceNumberFromPayload(payload []byte) int {
 	if len(payload) < 2 || len(payload)%2 != 0 {
 		return -1
 	}
-	i := binary.BigEndian.Uint16(payload)
-	for off := 2; off < len(payload); off += 2 {
-		if binary.BigEndian.Uint16(payload[off:]) != i {
-			return -1
-		}
-	}
-	return int(i)
+	return int(binary.BigEndian.Uint16(payload))
 }
 
-// verifyRTPPacket verifies a packet against itself. The header's sequence number is taken
-// as the source of truth for which packet this is meant to be; the timestamp and the
-// payload must both agree with it.
 func verifyRTPPacket(h *rtp.Header, payload []byte) error {
 	// Ensure that the header is properly written to.
 	if h.Version == 0 && h.PayloadType == 0 && h.SSRC == 0 && h.SequenceNumber == 0 && h.Timestamp == 0 {
 		return fmt.Errorf("header never written: ReadRTP reported %d bytes carrying packet %d, but left the header zeroed",
-			len(payload), payloadIndex(payload))
+			len(payload), sequenceNumberFromPayload(payload))
 	}
 	if h.Version != 2 || h.PayloadType != testPayloadType || h.SSRC != testStreamSSRC {
 		return fmt.Errorf("torn header: got version=%d pt=%d ssrc=%#x, want version=2 pt=%d ssrc=%#x (seq=%d ts=%d)",
@@ -97,15 +88,12 @@ func verifyRTPPacket(h *rtp.Header, payload []byte) error {
 			sequenceNumber, exp, h.Timestamp)
 	}
 	if len(payload) != testPayloadSize {
-		return fmt.Errorf("stale length: header says seq=%d, but ReadRTP returned %d payload bytes, want %d",
+		return fmt.Errorf("unexpected payload length: header says seq=%d, but ReadRTP returned %d payload bytes, want %d",
 			sequenceNumber, len(payload), testPayloadSize)
 	}
-	switch got := payloadIndex(payload); got {
+	switch got := sequenceNumberFromPayload(payload); got {
 	case sequenceNumber:
 		return nil
-	case -1:
-		return fmt.Errorf("mixed payload: header says seq=%d, but the buffer holds bytes from more than one packet",
-			sequenceNumber)
 	default:
 		return fmt.Errorf("mixed payload: header says seq=%d, but the buffer holds packet %d",
 			sequenceNumber, got)

--- a/rtp/session_test.go
+++ b/rtp/session_test.go
@@ -1,0 +1,197 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rtp
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/pion/rtp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/livekit/protocol/logger"
+)
+
+const (
+	testStreamSSRC   = 0x11223344
+	testSentinelSSRC = 0x55667788
+	testPayloadType  = 8   // PCMA
+	testPayloadSize  = 160 // 20ms of PCMA; a realistic size, and a wider copy() race window
+	testClockPerPkt  = 160
+)
+
+func newRTPPacket(t *testing.T, ssrc uint32, sequenceNumber int) []byte {
+	t.Helper()
+	require.Less(t, sequenceNumber, 1<<16, "index must fit the 16-bit sequence number")
+	p := rtp.Packet{
+		Header: rtp.Header{
+			Version:        2,
+			PayloadType:    testPayloadType,
+			SequenceNumber: uint16(sequenceNumber),
+			Timestamp:      uint32(sequenceNumber) * testClockPerPkt,
+			SSRC:           ssrc,
+		},
+		Payload: indexPayload(sequenceNumber),
+	}
+	buf, err := p.Marshal()
+	require.NoError(t, err)
+	return buf
+}
+
+func indexPayload(sequenceNumber int) []byte {
+	payload := make([]byte, testPayloadSize)
+	for off := 0; off < len(payload); off += 2 {
+		binary.BigEndian.PutUint16(payload[off:], uint16(sequenceNumber))
+	}
+	return payload
+}
+
+// payloadIndex recovers the packet index from a payload built by indexPayload, or -1 if
+// the payload is not a single repeated index - meaning bytes from two different packets
+// were interleaved into the buffer.
+func payloadIndex(payload []byte) int {
+	if len(payload) < 2 || len(payload)%2 != 0 {
+		return -1
+	}
+	i := binary.BigEndian.Uint16(payload)
+	for off := 2; off < len(payload); off += 2 {
+		if binary.BigEndian.Uint16(payload[off:]) != i {
+			return -1
+		}
+	}
+	return int(i)
+}
+
+// verifyRTPPacket verifies a packet against itself. The header's sequence number is taken
+// as the source of truth for which packet this is meant to be; the timestamp and the
+// payload must both agree with it.
+func verifyRTPPacket(h *rtp.Header, payload []byte) error {
+	// Ensure that the header is properly written to.
+	if h.Version == 0 && h.PayloadType == 0 && h.SSRC == 0 && h.SequenceNumber == 0 && h.Timestamp == 0 {
+		return fmt.Errorf("header never written: ReadRTP reported %d bytes carrying packet %d, but left the header zeroed",
+			len(payload), payloadIndex(payload))
+	}
+	if h.Version != 2 || h.PayloadType != testPayloadType || h.SSRC != testStreamSSRC {
+		return fmt.Errorf("torn header: got version=%d pt=%d ssrc=%#x, want version=2 pt=%d ssrc=%#x (seq=%d ts=%d)",
+			h.Version, h.PayloadType, h.SSRC, testPayloadType, uint32(testStreamSSRC), h.SequenceNumber, h.Timestamp)
+	}
+	sequenceNumber := int(h.SequenceNumber)
+	if exp := uint32(sequenceNumber) * testClockPerPkt; h.Timestamp != exp {
+		return fmt.Errorf("torn header: seq=%d implies ts=%d, got ts=%d - header fields came from two packets",
+			sequenceNumber, exp, h.Timestamp)
+	}
+	if len(payload) != testPayloadSize {
+		return fmt.Errorf("stale length: header says seq=%d, but ReadRTP returned %d payload bytes, want %d",
+			sequenceNumber, len(payload), testPayloadSize)
+	}
+	switch got := payloadIndex(payload); got {
+	case sequenceNumber:
+		return nil
+	case -1:
+		return fmt.Errorf("mixed payload: header says seq=%d, but the buffer holds bytes from more than one packet",
+			sequenceNumber)
+	default:
+		return fmt.Errorf("mixed payload: header says seq=%d, but the buffer holds packet %d",
+			sequenceNumber, got)
+	}
+}
+
+func TestSessionZeroCopyHandoff(t *testing.T) {
+	// Deliberately not gated on enableZeroCopy: "every delivered packet is internally
+	// consistent" must hold on both delivery paths, so this test is also the check that
+	// compiling the handoff out is a safe mitigation.
+	for i := range 10 {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			testZeroCopyHandoff(t, 8000)
+		})
+	}
+}
+
+func testZeroCopyHandoff(t *testing.T, packets int) {
+	cli, srv := net.Pipe()
+	defer cli.Close()
+	require.NoError(t, srv.SetReadDeadline(time.Now().Add(30*time.Second)))
+
+	sess := NewSession(logger.GetLogger(), srv)
+	defer sess.Close()
+
+	// TODO(alexfish): Clean this up.
+
+	// Blast one SSRC with no pacing, so the pump delivers packets microseconds apart
+	// rather than a frame apart, then a sentinel SSRC to mark the end of the run.
+	sent := make([][]byte, 0, packets+1)
+	for i := range packets {
+		sent = append(sent, newRTPPacket(t, testStreamSSRC, i))
+	}
+	sent = append(sent, newRTPPacket(t, testSentinelSSRC, 0))
+
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		for _, p := range sent {
+			if _, err := cli.Write(p); err != nil {
+				return
+			}
+		}
+	})
+
+	// The first AcceptStream returns the stream for testStreamSSRC. Its first packet is
+	// already sitting in r.recv - AcceptStream calls r.write before it returns.
+	r, ssrc, err := sess.AcceptStream()
+	require.NoError(t, err)
+	require.EqualValues(t, uint32(testStreamSSRC), ssrc)
+
+	allReceived := make(chan struct{})
+	wg.Go(func() {
+		defer close(allReceived)
+		for {
+			_, ssrc, err := sess.AcceptStream()
+			if err != nil || ssrc == testSentinelSSRC {
+				return
+			}
+		}
+	})
+
+	var delivered int
+	var verifyErr error
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		var h rtp.Header
+		buf := make([]byte, MTUSize+1)
+		for {
+			h = rtp.Header{}
+			n, err := r.ReadRTP(&h, buf)
+			if err != nil {
+				return
+			}
+			delivered++
+			if verifyErr = verifyRTPPacket(&h, buf[:n]); verifyErr != nil {
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+	sess.Close() // releases the reader with io.EOF
+	<-done
+
+	require.NoError(t, verifyErr, "ReadRTP delivered a corrupted packet")
+	require.NotZero(t, delivered, "no packets were delivered")
+	t.Logf("delivered %d/%d packets", delivered, packets)
+}


### PR DESCRIPTION
There's a few race/race-like conditions in the current implementation of `rtp.readStream`:

1. For a given reader, and for a given order of packets written to `rtp.readStream`, it's possible for the packets to be read out of order, e.g.:
  - writer writes packet A to the stream, and it lands in the queue (since the stream hasn't been lent a buffer yet)
  - reader calls `ReadRTP` and it lends its buffer to `readStream`. the reader then parks itself on the `direct` select statement.
  - writer writes packet B to the stream, and it gets written to the borrowed buffer
  - in the select statement, the reader receives packet A if `c.recv` is selected, or packet B if `c.copied` is selected. If packet  A is received, then packet B is dropped when the defer statement is run (that nils out the lent buffer and header. If packet B is received, then there's an out-of-order receive.

This PR fixes the issue by ensuring a few things:

1. Whenever we attempt to read, always check to see if there's any queued packets first.
2. Hold the lock whenever:
  a. we write a packet to the stream
  b. we check to see if the reader should lend its buffer or not.

Also, add a test.
