### PR TITLE
feat: register Opus codec in media-sdk opus package

### DIFF
--- a/opus/codec.go
+++ b/opus/codec.go
@@ -1,0 +1,49 @@
+// Copyright 2024 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build cgo
+
+package opus
+
+import (
+	"github.com/livekit/protocol/logger"
+
+	media "github.com/livekit/media-sdk"
+)
+
+const SDPName = "opus/48000/2"
+
+func init() {
+	media.RegisterCodec(media.NewAudioCodec(media.CodecInfo{
+		SDPName:      SDPName,
+		SampleRate:   48000,
+		RTPClockRate: 48000,
+		RTPIsStatic:  false,
+		Priority:     10,
+		Disabled:     true,
+		FileExt:      "opus",
+	}, func(w media.PCM16Writer) media.WriteCloser[Sample] {
+		dec, err := Decode(w, 1, logger.GetLogger())
+		if err != nil {
+			return nil
+		}
+		return dec
+	}, func(w media.WriteCloser[Sample]) media.PCM16Writer {
+		enc, err := Encode(w, 1, logger.GetLogger())
+		if err != nil {
+			return nil
+		}
+		return enc
+	}))
+}

--- a/opus/codec.go
+++ b/opus/codec.go
@@ -26,13 +26,12 @@ const SDPName = "opus/48000/2"
 
 func init() {
 	media.RegisterCodec(media.NewAudioCodec(media.CodecInfo{
-		SDPName:      SDPName,
-		SampleRate:   48000,
-		RTPClockRate: 48000,
-		RTPIsStatic:  false,
-		Priority:     10,
-		Disabled:     true,
-		FileExt:      "opus",
+		SDPName:     SDPName,
+		SampleRate:  48000,
+		RTPIsStatic: false,
+		Priority:    10,
+		Disabled:    true,
+		FileExt:     "opus",
 	}, func(w media.PCM16Writer) media.WriteCloser[Sample] {
 		dec, err := Decode(w, 1, logger.GetLogger())
 		if err != nil {

--- a/opus/opus.go
+++ b/opus/opus.go
@@ -64,10 +64,46 @@ func Decode(w media.PCM16Writer, targetChannels int, logger logger.Logger) (Writ
 	}, nil
 }
 
+// EncodeOptions tunes the Opus encoder. Zero values keep libopus defaults.
+type EncodeOptions struct {
+	// Bitrate is the target encoder bitrate in bits/sec (e.g. 24000). 0 = auto.
+	Bitrate int
+	// Complexity is the encoder computational complexity 1-10. 0 = default.
+	Complexity int
+	// FEC enables in-band Forward Error Correction.
+	FEC bool
+	// PacketLossPercent is the expected packet loss 0-100, used to tune FEC.
+	PacketLossPercent int
+}
+
 func Encode(w Writer, channels int, logger logger.Logger) (media.PCM16Writer, error) {
+	return EncodeWith(w, channels, EncodeOptions{}, logger)
+}
+
+func EncodeWith(w Writer, channels int, opts EncodeOptions, logger logger.Logger) (media.PCM16Writer, error) {
 	enc, err := opus.NewEncoder(w.SampleRate(), channels, opus.AppVoIP)
 	if err != nil {
 		return nil, err
+	}
+	if opts.Bitrate > 0 {
+		if err = enc.SetBitrate(opts.Bitrate); err != nil {
+			return nil, fmt.Errorf("opus set bitrate: %w", err)
+		}
+	}
+	if opts.Complexity > 0 {
+		if err = enc.SetComplexity(opts.Complexity); err != nil {
+			return nil, fmt.Errorf("opus set complexity: %w", err)
+		}
+	}
+	if opts.FEC {
+		if err = enc.SetInBandFEC(true); err != nil {
+			return nil, fmt.Errorf("opus set fec: %w", err)
+		}
+		if opts.PacketLossPercent > 0 {
+			if err = enc.SetPacketLossPerc(opts.PacketLossPercent); err != nil {
+				return nil, fmt.Errorf("opus set packet loss: %w", err)
+			}
+		}
 	}
 	return &encoder{
 		w:      w,

--- a/opus/opus.go
+++ b/opus/opus.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build cgo
+
 package opus
 
 import (


### PR DESCRIPTION
## Summary

- registers Opus by package side effect, following the existing g711/g722/dtmf pattern
- keeps Opus opt-in via `Disabled: true` and exposes `SDPName = "opus/48000/2"`
- adds configurable encoder bitrate, complexity, in-band FEC, and packet-loss tuning through `EncodeWith`
- makes the CGO requirement explicit on both Opus source files

This carries forward all changes from #69 on top of the current `main` branch while preserving the original commits and authorship.

## Review feedback addressed

- omit `RTPClockRate` so `RegisterCodec` defaults it to `SampleRate`
- add the `//go:build cgo` constraint to `opus.go`

## Verification

- `gofmt` / `git diff --check`
- CI-equivalent native dependencies in a Go 1.26 Debian container
- all relevant packages compile and pass; the only local full-suite failures were pre-existing AMR-WB golden hashes on ARM64, while upstream CI runs x86_64

## Related

- Supersedes #69
- livekit/sip#712
- livekit/sip#738