### PR TITLE
jitter: treat a large backward sequence jump as a discontinuity

### DIFF
--- a/jitter/buffer.go
+++ b/jitter/buffer.go
@@ -201,7 +201,13 @@ func (b *Buffer) push(pkt *rtp.Packet, receivedAt time.Time) {
 		}
 	}
 
-	if b.initialized && before(pkt.SequenceNumber, b.prevSN) {
+	// A packet is "expired" only if it is behind prevSN *and* close to it. A
+	// packet far behind (outside the withinRange window) is a new sequence space,
+	// e.g. a B2BUA transfer switching sources mid-call, and is handled as a
+	// discontinuity below, the same as a far-ahead packet. Without this, a new
+	// stream starting anywhere in the 32768 numbers behind prevSN was dropped
+	// forever, since drops never advance prevSN.
+	if b.initialized && before(pkt.SequenceNumber, b.prevSN) && withinRange(pkt.SequenceNumber, b.prevSN) {
 		// packet expired
 		if !pkt.Padding {
 			b.stats.PacketsDropped++

--- a/jitter/buffer_test.go
+++ b/jitter/buffer_test.go
@@ -343,6 +343,12 @@ func (s *stream) discont() {
 	s.seq += math.MaxUint16 / 2
 }
 
+// jumpBack moves the next sequence number n behind the current one, emulating a
+// new source (transfer) whose sequence space happens to start behind the old one.
+func (s *stream) jumpBack(n uint16) {
+	s.seq -= n
+}
+
 const defaultPacketSize = 200
 
 var headerBytes = []byte{0xaa, 0xaa}
@@ -367,4 +373,57 @@ func (d *testDepacketizer) IsPartitionHead(payload []byte) bool {
 
 func (d *testDepacketizer) IsPartitionTail(marker bool, _ []byte) bool {
 	return marker
+}
+
+// A B2BUA transfer swaps the source mid-call; the new stream's sequence numbers
+// are unrelated to the old ones. When they land behind prevSN (up to 32768
+// behind) every packet was rejected as expired, and because drops never advance
+// prevSN the buffer stayed muted until the new stream caught up.
+func TestBackwardDiscontinuity(t *testing.T) {
+	out := make(chan []ExtPacket, 100)
+	b := NewBuffer(&testDepacketizer{}, testBufferLatency, chanFunc(t, out))
+	s := newTestStream()
+
+	i := 0
+	for ; i < 50; i++ {
+		b.Push(s.gen(true, true))
+		checkSample(t, out, 1)
+	}
+	s.jumpBack(8618) // captured call: 21294 -> 12676
+	for ; i < 100; i++ {
+		b.Push(s.gen(true, true))
+		checkSample(t, out, 1)
+	}
+
+	checkStats(t, b, &BufferStats{
+		PacketsPushed:  100,
+		PacketsLost:    0,
+		PacketsDropped: 0,
+		PacketsPopped:  100,
+		SamplesPopped:  100,
+	})
+}
+
+// A packet that is a little behind prevSN is still a late packet and must be dropped.
+func TestLatePacketStillDropped(t *testing.T) {
+	out := make(chan []ExtPacket, 100)
+	b := NewBuffer(&testDepacketizer{}, testBufferLatency, chanFunc(t, out))
+	s := newTestStream()
+
+	for i := 0; i < 20; i++ {
+		b.Push(s.gen(true, true))
+		checkSample(t, out, 1)
+	}
+	late := s.gen(true, true)
+	late.SequenceNumber -= 5 // already popped
+	b.Push(late)
+	checkSample(t, out, 0)
+
+	checkStats(t, b, &BufferStats{
+		PacketsPushed:  21,
+		PacketsLost:    0,
+		PacketsDropped: 1,
+		PacketsPopped:  20,
+		SamplesPopped:  20,
+	})
 }


### PR DESCRIPTION
## Summary

- `jitter.Buffer.push()` dropped any packet whose sequence number fell in the 32768-wide half-space behind `prevSN` (`before(seq, prevSN)`), and a dropped packet never advances `prevSN`. A stream that re-anchors *behind* the previous one (a B2BUA transfer, a PBX relaying a new call leg) was therefore muted until its sequence numbers climbed past the old high-water mark: up to `prevSN - newSN` packets, e.g. 8618 packets / ~172 s at 50 pps on a captured PCMU call (old stream at seq 21294, new stream starting at 12676).
- The buffer already treats a jump larger than the 3000-packet `withinRange` window as a discontinuity, but only for *forward* jumps, because that check runs after the drop. This change makes the drop apply only to packets that are behind `prevSN` **and** within the window (a genuinely late packet). A far-behind packet now takes the existing discontinuity path, so `prevSN` resyncs on the new space with no further changes.
- Tests: `TestBackwardDiscontinuity` (the captured jump; fails before, passes after) and `TestLatePacketStillDropped` (a packet a few behind `prevSN` is still dropped and counted).

## Notes for reviewers

- The buffer is generic over `Depacketizer`. In-repo the only user is `rtp.HandleJitter` (audio, every packet is a partition head). For a non-audio consumer the 3000-packet window is seconds rather than a minute, and a far-behind packet that is *not* a partition head would get `discont = false` and could inflate `PacketsLost` by the uint16 gap. Neither is reachable on the audio path; flagging so it does not have to be derived.
- Adjacent but separate: `Buffer.Close()` stops the timer and breaks the fuse but does not join the pop goroutine, so a pop in flight can still call `onPacket` after `Close()` returns. Pre-existing; not changed here.
- Companion change in `livekit/sip` gives each incoming SSRC its own jitter buffer, which covers the new-SSRC case independently of this fix: https://github.com/livekit/sip/pull/828

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MND95Kk3MD7828eZBw8ipa
