### PR TITLE
Refactor to allow negotiating codec params.

### DIFF
--- a/amrwb/amrwb.go
+++ b/amrwb/amrwb.go
@@ -18,6 +18,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strconv"
+	"strings"
 
 	"github.com/livekit/amrwb-cgo"
 
@@ -39,20 +41,64 @@ const (
 )
 
 func init() {
-	media.RegisterCodec(media.NewAudioCodec(media.CodecInfo{
-		SDPName:     SDPNameAndRate,
-		SampleRate:  SampleRate,
+	info := media.CodecTypeInfo{
+		Name:        SDPNameOnly,
 		RTPIsStatic: false,
 		Priority:    -4,
 		FileExt:     "amrwb",
-		Disabled:    true,
-		ReqParams: []media.CodecParam{
-			{Key: "octet-align", Val: "0"},
-		},
-	}, func(w media.PCM16Writer) media.WriteCloser[Sample] {
-		return Decode(w, RTPBandwidthEfficient)
-	}, func(w media.WriteCloser[Sample]) media.PCM16Writer {
-		return Encode(w, RTPBandwidthEfficient)
+	}
+	media.RegisterCodec(media.NewAudioCodecType(info, func(c media.CodecConfig) (media.CodecInfo, media.CreateFunc, bool) {
+		if c.Channels != 0 && c.Channels != 1 {
+			return media.CodecInfo{}, nil, false
+		}
+		if c.SampleRate == 0 {
+			c.SampleRate = SampleRate
+		}
+		if c.SampleRate != SampleRate {
+			return media.CodecInfo{}, nil, false
+		}
+		const (
+			paramOctetAlign = "octet-align"
+			paramModeSet    = "mode-set"
+		)
+		var (
+			format   = RTPBandwidthEfficient
+			mode     = amrwb.Best
+			accepted media.CodecParams
+		)
+
+		// Select between bandwidth-efficient format (bit packing) and octet-aligned modes (align with pad bits).
+		if v, ok := c.Params.Get(paramOctetAlign); ok && v != "0" {
+			// TODO: support octet-aligned mode
+			return media.CodecInfo{}, nil, false
+		}
+		accepted.Add(paramOctetAlign, "0")
+
+		// Pick the best mode the peer can support.
+		// TODO: we should probably change the priority of the codec based on this as well
+		maxMode := -1
+		if v, ok := c.Params.Get(paramModeSet); ok {
+			for s := range strings.FieldsSeq(v) {
+				m, err := strconv.Atoi(s)
+				if err != nil {
+					return media.CodecInfo{}, nil, false
+				}
+				maxMode = max(m, maxMode)
+			}
+		}
+		if maxMode >= 0 {
+			mode = amrwb.Mode(maxMode)
+		}
+		accepted.Add(paramModeSet, strconv.Itoa(int(mode)))
+
+		info := media.CodecInfo{CodecTypeInfo: info, CodecConfig: c}
+		info.Params = accepted
+		create := media.NewAudioCodecFunc(info, func(w media.PCM16Writer) media.WriteCloser[Sample] {
+			return Decode(w, format)
+		}, func(w media.WriteCloser[Sample]) media.PCM16Writer {
+			return EncodeWith(w, format, mode)
+		})
+		return info, create, true
 	}))
 }
 

--- a/amrwb/amrwb.go
+++ b/amrwb/amrwb.go
@@ -43,11 +43,12 @@ const (
 func init() {
 	info := media.CodecTypeInfo{
 		Name:        SDPNameOnly,
+		Kind:        media.Audio,
 		RTPIsStatic: false,
 		Priority:    -4,
 		FileExt:     "amrwb",
 	}
-	media.RegisterCodec(media.NewAudioCodecType(info, func(c media.CodecConfig) (media.CodecInfo, media.CreateFunc, bool) {
+	media.RegisterCodec(media.NewCodec(info, nil, func(c media.CodecConfig) (media.CodecInfo, media.CreateFunc, bool) {
 		if c.Channels != 0 && c.Channels != 1 {
 			return media.CodecInfo{}, nil, false
 		}
@@ -78,7 +79,10 @@ func init() {
 		// TODO: we should probably change the priority of the codec based on this as well
 		maxMode := -1
 		if v, ok := c.Params.Get(paramModeSet); ok {
-			for s := range strings.FieldsSeq(v) {
+			for s := range strings.SplitSeq(v, ",") {
+				if s == "" {
+					continue
+				}
 				m, err := strconv.Atoi(s)
 				if err != nil {
 					return media.CodecInfo{}, nil, false

--- a/audio.go
+++ b/audio.go
@@ -39,33 +39,24 @@ type AudioFrameCodec[S BytesFrame] interface {
 type AudioDecodeFunc[S Frame] func(w PCM16Writer) WriteCloser[S]
 type AudioEncodeFunc[S Frame] func(w WriteCloser[S]) PCM16Writer
 
-// NewAudioCodec creates an audio codec with a given encode and decode implementations.
-func NewAudioCodec[S BytesFrame](
-	info CodecInfo,
-	decode AudioDecodeFunc[S],
-	encode AudioEncodeFunc[S],
-) AudioFrameCodec[S] {
-	if info.SampleRate <= 0 {
-		panic("invalid sample rate")
-	}
+// NewAudioCodecFunc is a helper to define a CreateFunc for an audio codec.
+func NewAudioCodecFunc[S BytesFrame](info CodecInfo, decode AudioDecodeFunc[S], encode AudioEncodeFunc[S]) CreateFunc {
 	if info.RTPClockRate == 0 {
 		info.RTPClockRate = info.SampleRate
 	}
-	return &audioCodec[S]{
-		info:   info,
-		encode: encode,
-		decode: decode,
+	return func() Codec {
+		return &audioCodec[S]{
+			CodecInfo: info,
+			decode:    decode,
+			encode:    encode,
+		}
 	}
 }
 
 type audioCodec[S BytesFrame] struct {
-	info   CodecInfo
+	CodecInfo
 	decode AudioDecodeFunc[S]
 	encode AudioEncodeFunc[S]
-}
-
-func (c *audioCodec[S]) Info() CodecInfo {
-	return c.info
 }
 
 func (c *audioCodec[S]) Encode(w WriteCloser[S]) PCM16Writer {
@@ -77,7 +68,7 @@ func (c *audioCodec[S]) Decode(w PCM16Writer) WriteCloser[S] {
 }
 
 func (c *audioCodec[S]) EncodeBytes(w BytesWriter) PCM16Writer {
-	bw := EncodeBytes[S](w, c.info.SampleRate)
+	bw := EncodeBytes[S](w, c.SampleRate)
 	return c.encode(bw)
 }
 

--- a/codecs.go
+++ b/codecs.go
@@ -20,6 +20,14 @@ import (
 	"strings"
 )
 
+type Kind int
+
+const (
+	Unknown = Kind(iota)
+	Audio
+	Data
+)
+
 type CodecParams []CodecParam
 
 func (arr CodecParams) String() string {
@@ -87,6 +95,7 @@ type CodecConfig struct {
 
 type CodecTypeInfo struct {
 	Name        string // codec name for SDP, must not contain '/' parameters
+	Kind        Kind
 	RTPDefType  byte
 	RTPIsStatic bool
 	Priority    int // higher is preferable
@@ -104,7 +113,7 @@ func (c *CodecTypeInfo) Info() CodecTypeInfo {
 }
 
 type CreateFunc func() Codec
-type OfferFunc func(s *CodecSet) []CodecConfig
+type OfferFunc func(s *CodecSet) []CodecInfo
 type SupportsFunc func(c CodecConfig) (CodecInfo, CreateFunc, bool)
 
 type CodecType interface {
@@ -113,7 +122,7 @@ type CodecType interface {
 	// Info returns static information about this codec.
 	Info() CodecTypeInfo
 	// Offer lists the default set of codec configurations for SDP offers.
-	Offer(s *CodecSet) []CodecConfig
+	Offer(s *CodecSet) []CodecInfo
 	// Supports checks if a given codec configuration is supported.
 	// It returns full codec information for it with accepted configuration, and a constructor for creating the codec.
 	Supports(c CodecConfig) (CodecInfo, CreateFunc, bool)
@@ -137,7 +146,14 @@ func (c *CodecInfo) SDPFullName() string {
 }
 
 func (c *CodecInfo) Info() CodecInfo {
+	c.Defaults()
 	return *c
+}
+
+func (c *CodecInfo) Defaults() {
+	if c.RTPClockRate == 0 {
+		c.RTPClockRate = c.SampleRate
+	}
 }
 
 // Codec is a configured instance of a CodecType.
@@ -179,6 +195,9 @@ func (s *CodecSet) NewSet() *CodecSet {
 
 // SetEnabled enables or disables a given codec.
 func (s *CodecSet) SetEnabled(name string, enabled bool) {
+	if i := strings.IndexByte(name, '/'); i >= 0 {
+		name = name[:i]
+	}
 	name = strings.ToLower(name)
 	s.enabled[name] = enabled
 }
@@ -194,6 +213,9 @@ func (s *CodecSet) SetEnabledMap(codecs map[string]bool) {
 func (s *CodecSet) IsEnabledByName(name string) bool {
 	if s == nil {
 		return false
+	}
+	if i := strings.IndexByte(name, '/'); i >= 0 {
+		name = name[:i]
 	}
 	name = strings.ToLower(name)
 	for s := s; s != nil; s = s.parent {
@@ -277,14 +299,24 @@ func RegisterCodec(c CodecType) {
 
 // NewCodec creates a generic codec definition without a specific implementation.
 func NewCodec(info CodecTypeInfo, offer OfferFunc, support SupportsFunc) CodecType {
+	if info.Name == "" {
+		panic("codec name must be specified")
+	}
+	if strings.ContainsAny(info.Name, " /") {
+		panic("invalid codec name: must not contain '/' or spaces")
+	}
+	if info.Kind == Unknown {
+		panic("codec kind must be specified")
+	}
 	if offer == nil {
 		// Use default config that SupportsFunc generates.
-		offer = func(c *CodecSet) []CodecConfig {
+		offer = func(c *CodecSet) []CodecInfo {
 			info, _, ok := support(CodecConfig{})
 			if !ok {
 				return nil // no default
 			}
-			return []CodecConfig{info.CodecConfig}
+			info.Defaults()
+			return []CodecInfo{info}
 		}
 	}
 	return &baseCodecType{CodecTypeInfo: info, offer: offer, support: support}
@@ -296,13 +328,21 @@ type baseCodecType struct {
 	support SupportsFunc
 }
 
-func (t *baseCodecType) Offer(s *CodecSet) []CodecConfig {
+func (t *baseCodecType) Offer(s *CodecSet) []CodecInfo {
 	if !s.IsEnabled(t) {
 		return nil
 	}
-	return t.offer(s)
+	out := t.offer(s)
+	for i := range out {
+		out[i].Defaults()
+	}
+	return out
 }
 
 func (t *baseCodecType) Supports(c CodecConfig) (CodecInfo, CreateFunc, bool) {
-	return t.support(c)
+	info, create, ok := t.support(c)
+	if ok {
+		info.Defaults()
+	}
+	return info, create, ok
 }

--- a/codecs.go
+++ b/codecs.go
@@ -15,6 +15,7 @@
 package media
 
 import (
+	"fmt"
 	"slices"
 	"strings"
 )
@@ -62,6 +63,10 @@ func (arr CodecParams) HasParam(p2 CodecParam) bool {
 	return false
 }
 
+func (arr *CodecParams) Add(key, val string) {
+	*arr = append(*arr, CodecParam{Key: key, Val: val})
+}
+
 type CodecParam struct {
 	Key string
 	Val string
@@ -74,27 +79,76 @@ func (p CodecParam) String() string {
 	return p.Key + "=" + p.Val
 }
 
-type CodecInfo struct {
-	SDPName      string
-	SampleRate   int
-	RTPClockRate int
-	RTPDefType   byte
-	RTPIsStatic  bool
-	Priority     int  // higher is preferable
-	Disabled     bool // codec is disabled in GlobalCodecs by default
-	Hidden       bool // codec should not appear in SDP offer, but can be used in the answer
-	FileExt      string
-	ReqParams    CodecParams // a list of required codec params (fmtp)
+type CodecConfig struct {
+	SampleRate int         // codec sample rate (opus/<rate>)
+	Channels   int         // number of channels if specified (opus/48000/<channels>)
+	Params     CodecParams // a list of codec params (fmtp)
 }
 
+type CodecTypeInfo struct {
+	Name        string // codec name for SDP, must not contain '/' parameters
+	RTPDefType  byte
+	RTPIsStatic bool
+	Priority    int // higher is preferable
+	FileExt     string
+}
+
+func (c *CodecTypeInfo) String() string {
+	return c.SDPName()
+}
+func (c *CodecTypeInfo) SDPName() string {
+	return c.Name
+}
+func (c *CodecTypeInfo) Info() CodecTypeInfo {
+	return *c
+}
+
+type CreateFunc func() Codec
+type OfferFunc func(s *CodecSet) []CodecConfig
+type SupportsFunc func(c CodecConfig) (CodecInfo, CreateFunc, bool)
+
+type CodecType interface {
+	// SDPName is a name of the codec in SDP. Must not contain '/' parameters.
+	SDPName() string
+	// Info returns static information about this codec.
+	Info() CodecTypeInfo
+	// Offer lists the default set of codec configurations for SDP offers.
+	Offer(s *CodecSet) []CodecConfig
+	// Supports checks if a given codec configuration is supported.
+	// It returns full codec information for it with accepted configuration, and a constructor for creating the codec.
+	Supports(c CodecConfig) (CodecInfo, CreateFunc, bool)
+}
+
+type CodecInfo struct {
+	CodecTypeInfo
+	CodecConfig
+	RTPClockRate int
+}
+
+func (c *CodecInfo) String() string {
+	return c.SDPFullName()
+}
+
+func (c *CodecInfo) SDPFullName() string {
+	if c.Channels == 0 {
+		return fmt.Sprintf("%s/%d", c.SDPName(), c.RTPClockRate)
+	}
+	return fmt.Sprintf("%s/%d/%d", c.SDPName(), c.RTPClockRate, c.Channels)
+}
+
+func (c *CodecInfo) Info() CodecInfo {
+	return *c
+}
+
+// Codec is a configured instance of a CodecType.
 type Codec interface {
 	Info() CodecInfo
 }
 
 var (
 	globalSet       = NewCodecSet()
-	codecs          []Codec
-	codecOnRegister []func(c Codec)
+	codecs          []CodecType
+	codecOnRegister []func(c CodecType)
 )
 
 // GlobalCodecs returns a shared codec set.
@@ -151,19 +205,19 @@ func (s *CodecSet) IsEnabledByName(name string) bool {
 }
 
 // IsEnabled checks if a given codec is enabled.
-func (s *CodecSet) IsEnabled(c Codec) bool {
+func (s *CodecSet) IsEnabled(c CodecType) bool {
 	if s == nil || c == nil {
 		return false
 	}
-	return s.IsEnabledByName(c.Info().SDPName)
+	return s.IsEnabledByName(c.SDPName())
 }
 
 // ListEnabled lists all enabled codecs.
-func (s *CodecSet) ListEnabled() []Codec {
+func (s *CodecSet) ListEnabled() []CodecType {
 	if s == nil {
 		return nil
 	}
-	out := make([]Codec, 0, len(codecs))
+	out := make([]CodecType, 0, len(codecs))
 	for _, c := range codecs {
 		if s.IsEnabled(c) {
 			out = append(out, c)
@@ -183,7 +237,7 @@ func CodecsSetEnabled(codecs map[string]bool) {
 }
 
 // CodecEnabled checks if the codec is enabled in the GlobalCodecs set.
-func CodecEnabled(c Codec) bool {
+func CodecEnabled(c CodecType) bool {
 	return GlobalCodecs().IsEnabled(c)
 }
 
@@ -192,7 +246,7 @@ func CodecEnabledByName(name string) bool {
 	return GlobalCodecs().IsEnabledByName(name)
 }
 
-func OnRegister(fnc func(c Codec)) {
+func OnRegister(fnc func(c CodecType)) {
 	// Call it on already registered codecs first, so that the import order doesn't matter.
 	for _, c := range codecs {
 		fnc(c)
@@ -202,41 +256,53 @@ func OnRegister(fnc func(c Codec)) {
 }
 
 // Codecs lists all registered codecs.
-func Codecs() []Codec {
+func Codecs() []CodecType {
 	return slices.Clone(codecs)
 }
 
 // EnabledCodecs lists all codecs enabled in the GlobalCodecs set.
-func EnabledCodecs() []Codec {
+func EnabledCodecs() []CodecType {
 	return GlobalCodecs().ListEnabled()
 }
 
 // RegisterCodec registers the codec.
-func RegisterCodec(c Codec) {
-	info := c.Info()
+func RegisterCodec(c CodecType) {
 	global := GlobalCodecs()
 	codecs = append(codecs, c)
-	global.SetEnabled(info.SDPName, !info.Disabled)
+	global.SetEnabled(c.SDPName(), true)
 	for _, fnc := range codecOnRegister {
 		fnc(c)
 	}
 }
 
 // NewCodec creates a generic codec definition without a specific implementation.
-func NewCodec(info CodecInfo) Codec {
-	if info.SampleRate <= 0 {
-		panic("invalid sample rate")
+func NewCodec(info CodecTypeInfo, offer OfferFunc, support SupportsFunc) CodecType {
+	if offer == nil {
+		// Use default config that SupportsFunc generates.
+		offer = func(c *CodecSet) []CodecConfig {
+			info, _, ok := support(CodecConfig{})
+			if !ok {
+				return nil // no default
+			}
+			return []CodecConfig{info.CodecConfig}
+		}
 	}
-	if info.RTPClockRate == 0 {
-		info.RTPClockRate = info.SampleRate
-	}
-	return &baseCodec{info: info}
+	return &baseCodecType{CodecTypeInfo: info, offer: offer, support: support}
 }
 
-type baseCodec struct {
-	info CodecInfo
+type baseCodecType struct {
+	CodecTypeInfo
+	offer   OfferFunc
+	support SupportsFunc
 }
 
-func (c *baseCodec) Info() CodecInfo {
-	return c.info
+func (t *baseCodecType) Offer(s *CodecSet) []CodecConfig {
+	if !s.IsEnabled(t) {
+		return nil
+	}
+	return t.offer(s)
+}
+
+func (t *baseCodecType) Supports(c CodecConfig) (CodecInfo, CreateFunc, bool) {
+	return t.support(c)
 }

--- a/codecs.go
+++ b/codecs.go
@@ -75,6 +75,19 @@ func (arr *CodecParams) Add(key, val string) {
 	*arr = append(*arr, CodecParam{Key: key, Val: val})
 }
 
+func (arr CodecParams) Equals(arr2 CodecParams) bool {
+	if len(arr) != len(arr2) {
+		return false
+	}
+	for i := range arr {
+		p1, p2 := arr[i], arr2[i]
+		if p1 != p2 {
+			return false
+		}
+	}
+	return true
+}
+
 type CodecParam struct {
 	Key string
 	Val string
@@ -93,6 +106,17 @@ type CodecConfig struct {
 	Params     CodecParams // a list of codec params (fmtp)
 }
 
+func (c *CodecConfig) Equals(c2 *CodecConfig) bool {
+	if c == nil && c2 == nil {
+		return true
+	} else if c == nil || c2 == nil {
+		return false
+	}
+	return c.SampleRate == c2.SampleRate &&
+		c.Channels == c2.Channels &&
+		c.Params.Equals(c2.Params)
+}
+
 type CodecTypeInfo struct {
 	Name        string // codec name for SDP, must not contain '/' parameters
 	Kind        Kind
@@ -102,14 +126,14 @@ type CodecTypeInfo struct {
 	FileExt     string
 }
 
-func (c *CodecTypeInfo) String() string {
+func (c CodecTypeInfo) String() string {
 	return c.SDPName()
 }
-func (c *CodecTypeInfo) SDPName() string {
+func (c CodecTypeInfo) SDPName() string {
 	return c.Name
 }
-func (c *CodecTypeInfo) Info() CodecTypeInfo {
-	return *c
+func (c CodecTypeInfo) Info() CodecTypeInfo {
+	return c
 }
 
 type CreateFunc func() Codec
@@ -134,26 +158,35 @@ type CodecInfo struct {
 	RTPClockRate int
 }
 
-func (c *CodecInfo) String() string {
+func (c CodecInfo) String() string {
 	return c.SDPFullName()
 }
 
-func (c *CodecInfo) SDPFullName() string {
+func (c CodecInfo) SDPFullName() string {
 	if c.Channels == 0 {
 		return fmt.Sprintf("%s/%d", c.SDPName(), c.RTPClockRate)
 	}
 	return fmt.Sprintf("%s/%d/%d", c.SDPName(), c.RTPClockRate, c.Channels)
 }
 
-func (c *CodecInfo) Info() CodecInfo {
+func (c CodecInfo) Info() CodecInfo {
 	c.Defaults()
-	return *c
+	return c
 }
 
 func (c *CodecInfo) Defaults() {
 	if c.RTPClockRate == 0 {
 		c.RTPClockRate = c.SampleRate
 	}
+}
+
+func (c *CodecInfo) Equals(c2 *CodecInfo) bool {
+	if c == nil && c2 == nil {
+		return true
+	} else if c == nil || c2 == nil {
+		return false
+	}
+	return c.Name == c2.Name && c.CodecConfig.Equals(&c2.CodecConfig)
 }
 
 // Codec is a configured instance of a CodecType.

--- a/dtmf/dtmf.go
+++ b/dtmf/dtmf.go
@@ -34,10 +34,11 @@ const (
 func init() {
 	info := media.CodecTypeInfo{
 		Name:        SDPNameOnly,
+		Kind:        media.Data,
 		RTPIsStatic: false,
 		Priority:    -100, // let it be last in SDP
 	}
-	media.RegisterCodec(media.NewCodec(info, func(s *media.CodecSet) []media.CodecConfig {
+	media.RegisterCodec(media.NewCodec(info, func(s *media.CodecSet) []media.CodecInfo {
 		// Check rates that other codecs advertise.
 		var rates []int
 		for _, c := range s.ListEnabled() {
@@ -56,9 +57,10 @@ func init() {
 			}
 		}
 		slices.Sort(rates)
-		out := make([]media.CodecConfig, 0, len(rates))
+		out := make([]media.CodecInfo, 0, len(rates))
 		for _, rate := range rates {
-			out = append(out, media.CodecConfig{SampleRate: rate})
+			cc := media.CodecConfig{SampleRate: rate, Params: []media.CodecParam{{Key: "0-16"}}}
+			out = append(out, media.CodecInfo{CodecTypeInfo: info, CodecConfig: cc})
 		}
 		return out
 	}, func(c media.CodecConfig) (media.CodecInfo, media.CreateFunc, bool) {
@@ -67,13 +69,13 @@ func init() {
 			return media.CodecInfo{}, nil, false
 		}
 		const rateInc = 8000
-		if c.SampleRate%rateInc == 0 {
+		if c.SampleRate%rateInc != 0 {
 			return media.CodecInfo{}, nil, false
 		}
 		i := c.SampleRate / rateInc
 		info := media.CodecInfo{CodecTypeInfo: info, CodecConfig: c}
 		info.Priority -= i // order by rate
-		info.Params = nil  // TODO: currently handled externally
+		info.Params = []media.CodecParam{{Key: "0-16"}}
 		return info, nil, true
 	}))
 }

--- a/dtmf/dtmf.go
+++ b/dtmf/dtmf.go
@@ -17,9 +17,9 @@ package dtmf
 import (
 	"context"
 	"encoding/binary"
-	"fmt"
 	"io"
 	"math"
+	"slices"
 	"time"
 
 	"github.com/livekit/media-sdk"
@@ -32,16 +32,50 @@ const (
 )
 
 func init() {
-	for i, rate := range []int{
-		8000, 16000, 48000,
-	} {
-		media.RegisterCodec(media.NewCodec(media.CodecInfo{
-			SDPName:     fmt.Sprintf("%s/%d", SDPNameOnly, rate),
-			SampleRate:  rate,
-			RTPIsStatic: false,
-			Priority:    -100 - i, // let it be last in SDP
-		}))
+	info := media.CodecTypeInfo{
+		Name:        SDPNameOnly,
+		RTPIsStatic: false,
+		Priority:    -100, // let it be last in SDP
 	}
+	media.RegisterCodec(media.NewCodec(info, func(s *media.CodecSet) []media.CodecConfig {
+		// Check rates that other codecs advertise.
+		var rates []int
+		for _, c := range s.ListEnabled() {
+			name := c.SDPName()
+			if name == SDPNameOnly {
+				continue
+			}
+			for _, cc := range c.Offer(s) {
+				rate := cc.SampleRate
+				if rate <= 0 {
+					continue
+				}
+				if !slices.Contains(rates, rate) {
+					rates = append(rates, rate)
+				}
+			}
+		}
+		slices.Sort(rates)
+		out := make([]media.CodecConfig, 0, len(rates))
+		for _, rate := range rates {
+			out = append(out, media.CodecConfig{SampleRate: rate})
+		}
+		return out
+	}, func(c media.CodecConfig) (media.CodecInfo, media.CreateFunc, bool) {
+		if c.SampleRate == 0 {
+			// Rate must be set from the audio codec.
+			return media.CodecInfo{}, nil, false
+		}
+		const rateInc = 8000
+		if c.SampleRate%rateInc == 0 {
+			return media.CodecInfo{}, nil, false
+		}
+		i := c.SampleRate / rateInc
+		info := media.CodecInfo{CodecTypeInfo: info, CodecConfig: c}
+		info.Priority -= i // order by rate
+		info.Params = nil  // TODO: currently handled externally
+		return info, nil, true
+	}))
 }
 
 const (

--- a/g711/alaw.go
+++ b/g711/alaw.go
@@ -30,14 +30,28 @@ const (
 )
 
 func init() {
-	media.RegisterCodec(media.NewAudioCodec(media.CodecInfo{
-		SDPName:     ALawSDPNameAndRate,
-		SampleRate:  8000,
+	info := media.CodecTypeInfo{
+		Name:        ALawSDPNameOnly,
 		RTPDefType:  prtp.PayloadTypePCMA,
 		RTPIsStatic: true,
 		Priority:    -20,
 		FileExt:     "g711a",
-	}, DecodeALaw, EncodeALaw))
+	}
+	media.RegisterCodec(media.NewCodec(info, nil, func(c media.CodecConfig) (media.CodecInfo, media.CreateFunc, bool) {
+		if c.Channels != 0 && c.Channels != 1 {
+			return media.CodecInfo{}, nil, false
+		}
+		if c.SampleRate == 0 {
+			c.SampleRate = 8000
+		}
+		if c.SampleRate != 8000 {
+			return media.CodecInfo{}, nil, false
+		}
+		info := media.CodecInfo{CodecTypeInfo: info, CodecConfig: c}
+		info.Params = nil
+		create := media.NewAudioCodecFunc(info, DecodeALaw, EncodeALaw)
+		return info, create, true
+	}))
 }
 
 type ALawSample []byte

--- a/g711/alaw.go
+++ b/g711/alaw.go
@@ -32,6 +32,7 @@ const (
 func init() {
 	info := media.CodecTypeInfo{
 		Name:        ALawSDPNameOnly,
+		Kind:        media.Audio,
 		RTPDefType:  prtp.PayloadTypePCMA,
 		RTPIsStatic: true,
 		Priority:    -20,

--- a/g711/ulaw.go
+++ b/g711/ulaw.go
@@ -32,6 +32,7 @@ const (
 func init() {
 	info := media.CodecTypeInfo{
 		Name:        ULawSDPNameOnly,
+		Kind:        media.Audio,
 		RTPDefType:  prtp.PayloadTypePCMU,
 		RTPIsStatic: true,
 		Priority:    -10,

--- a/g711/ulaw.go
+++ b/g711/ulaw.go
@@ -30,14 +30,28 @@ const (
 )
 
 func init() {
-	media.RegisterCodec(media.NewAudioCodec(media.CodecInfo{
-		SDPName:     ULawSDPNameAndRate,
-		SampleRate:  8000,
+	info := media.CodecTypeInfo{
+		Name:        ULawSDPNameOnly,
 		RTPDefType:  prtp.PayloadTypePCMU,
 		RTPIsStatic: true,
 		Priority:    -10,
 		FileExt:     "g711u",
-	}, DecodeULaw, EncodeULaw))
+	}
+	media.RegisterCodec(media.NewCodec(info, nil, func(c media.CodecConfig) (media.CodecInfo, media.CreateFunc, bool) {
+		if c.Channels != 0 && c.Channels != 1 {
+			return media.CodecInfo{}, nil, false
+		}
+		if c.SampleRate == 0 {
+			c.SampleRate = 8000
+		}
+		if c.SampleRate != 8000 {
+			return media.CodecInfo{}, nil, false
+		}
+		info := media.CodecInfo{CodecTypeInfo: info, CodecConfig: c}
+		info.Params = nil
+		create := media.NewAudioCodecFunc(info, DecodeULaw, EncodeULaw)
+		return info, create, true
+	}))
 }
 
 type ULawSample []byte

--- a/g722/g722.go
+++ b/g722/g722.go
@@ -40,6 +40,7 @@ var (
 func init() {
 	info := media.CodecTypeInfo{
 		Name:        SDPNameOnly,
+		Kind:        media.Audio,
 		RTPDefType:  prtp.PayloadTypeG722,
 		RTPIsStatic: true,
 		Priority:    -5,

--- a/g722/g722.go
+++ b/g722/g722.go
@@ -38,15 +38,31 @@ var (
 )
 
 func init() {
-	media.RegisterCodec(media.NewAudioCodec(media.CodecInfo{
-		SDPName:      SDPNameAndRate,
-		SampleRate:   16000,
-		RTPClockRate: 8000,
-		RTPDefType:   prtp.PayloadTypeG722,
-		RTPIsStatic:  true,
-		Priority:     -5,
-		FileExt:      "g722",
-	}, Decode, Encode))
+	info := media.CodecTypeInfo{
+		Name:        SDPNameOnly,
+		RTPDefType:  prtp.PayloadTypeG722,
+		RTPIsStatic: true,
+		Priority:    -5,
+		FileExt:     "g722",
+	}
+	media.RegisterCodec(media.NewCodec(info, nil, func(c media.CodecConfig) (media.CodecInfo, media.CreateFunc, bool) {
+		if c.Channels != 0 && c.Channels != 1 {
+			return media.CodecInfo{}, nil, false
+		}
+		const sdpRate = 8000 // known error in RFC
+		if c.SampleRate == 0 {
+			c.SampleRate = sdpRate
+		}
+		if c.SampleRate != sdpRate {
+			return media.CodecInfo{}, nil, false
+		}
+		info := media.CodecInfo{CodecTypeInfo: info, CodecConfig: c}
+		info.SampleRate = 16000
+		info.RTPClockRate = sdpRate
+		info.Params = nil
+		create := media.NewAudioCodecFunc(info, Decode, Encode)
+		return info, create, true
+	}))
 }
 
 type Sample []byte

--- a/opus/codec.go
+++ b/opus/codec.go
@@ -30,6 +30,7 @@ const (
 func init() {
 	info := media.CodecTypeInfo{
 		Name:        SDPNameOnly,
+		Kind:        media.Audio,
 		RTPIsStatic: false,
 		Priority:    10,
 		FileExt:     "opus",

--- a/opus/codec.go
+++ b/opus/codec.go
@@ -22,27 +22,49 @@ import (
 	media "github.com/livekit/media-sdk"
 )
 
-const SDPName = "opus/48000/2"
+const (
+	SDPNameOnly = "opus"
+	SDPName     = SDPNameOnly + "/48000/2"
+)
 
 func init() {
-	media.RegisterCodec(media.NewAudioCodec(media.CodecInfo{
-		SDPName:     SDPName,
-		SampleRate:  48000,
+	info := media.CodecTypeInfo{
+		Name:        SDPNameOnly,
 		RTPIsStatic: false,
 		Priority:    10,
-		Disabled:    true,
 		FileExt:     "opus",
-	}, func(w media.PCM16Writer) media.WriteCloser[Sample] {
-		dec, err := Decode(w, 1, logger.GetLogger())
-		if err != nil {
-			return nil
+	}
+	media.RegisterCodec(media.NewCodec(info, nil, func(c media.CodecConfig) (media.CodecInfo, media.CreateFunc, bool) {
+		switch c.Channels {
+		default:
+			return media.CodecInfo{}, nil, false
+		case 0, 1, 2:
 		}
-		return dec
-	}, func(w media.WriteCloser[Sample]) media.PCM16Writer {
-		enc, err := Encode(w, 1, logger.GetLogger())
-		if err != nil {
-			return nil
+		const defRate = 48000
+		if c.SampleRate == 0 {
+			c.SampleRate = 48000
 		}
-		return enc
+		if c.SampleRate != defRate {
+			return media.CodecInfo{}, nil, false
+		}
+		// TODO: support codec parameters
+
+		info := media.CodecInfo{CodecTypeInfo: info, CodecConfig: c}
+		info.Params = nil
+
+		create := media.NewAudioCodecFunc(info, func(w media.PCM16Writer) media.WriteCloser[Sample] {
+			dec, err := Decode(w, 1, logger.GetLogger())
+			if err != nil {
+				return nil
+			}
+			return dec
+		}, func(w media.WriteCloser[Sample]) media.PCM16Writer {
+			enc, err := Encode(w, 1, logger.GetLogger())
+			if err != nil {
+				return nil
+			}
+			return enc
+		})
+		return info, create, true
 	}))
 }

--- a/rtp/codecs.go
+++ b/rtp/codecs.go
@@ -17,16 +17,17 @@ package rtp
 import (
 	"fmt"
 
-	"github.com/livekit/media-sdk"
 	"github.com/pion/rtp"
+
+	"github.com/livekit/media-sdk"
 )
 
 var (
-	codecByType [0xff]media.Codec
+	codecByType [0xff]media.CodecType
 )
 
 func init() {
-	media.OnRegister(func(c media.Codec) {
+	media.OnRegister(func(c media.CodecType) {
 		info := c.Info()
 		if info.RTPIsStatic {
 			codecByType[info.RTPDefType] = c
@@ -34,7 +35,7 @@ func init() {
 	})
 }
 
-func CodecByPayloadType(typ byte) media.Codec {
+func CodecByPayloadType(typ byte) media.CodecType {
 	return codecByType[typ]
 }
 

--- a/rtp/codecs.go
+++ b/rtp/codecs.go
@@ -60,6 +60,34 @@ func (d *rawHandler) HandleRTP(h *rtp.Header, payload []byte) error {
 	return d.w.WriteRaw(payload)
 }
 
+func initCodec(t media.CodecType, cc media.CodecConfig) (media.AudioCodec, error) {
+	_, create, ok := t.Supports(cc)
+	if !ok {
+		return nil, fmt.Errorf("no support for PCM codec %q", t.SDPName())
+	}
+	ac, ok := create().(media.AudioCodec)
+	if !ok {
+		return nil, fmt.Errorf("cannot use codec %q for audio", t.SDPName())
+	}
+	return ac, nil
+}
+
+func DecodePCMWithCodec(w media.PCM16Writer, t media.CodecType, cc media.CodecConfig, typ byte) (HandlerCloser, error) {
+	ac, err := initCodec(t, cc)
+	if err != nil {
+		return nil, err
+	}
+	return DecodePCM(w, ac, typ), nil
+}
+
+func EncodePCMWithCodec(w *Stream, t media.CodecType, cc media.CodecConfig) (media.PCM16Writer, error) {
+	ac, err := initCodec(t, cc)
+	if err != nil {
+		return nil, err
+	}
+	return EncodePCM(w, ac), nil
+}
+
 func DecodePCM(w media.PCM16Writer, c media.AudioCodec, typ byte) HandlerCloser {
 	return HandlePayload(c.DecodeBytes(w), typ)
 }

--- a/sdp/codecs.go
+++ b/sdp/codecs.go
@@ -21,36 +21,31 @@ import (
 )
 
 var (
-	codecByName = make(map[string]media.Codec)
+	codecByName = make(map[string]media.CodecType)
 )
 
 func init() {
-	media.OnRegister(func(c media.Codec) {
-		name := c.Info().SDPName
+	media.OnRegister(func(c media.CodecType) {
+		name := c.SDPName()
 		if name != "" {
 			name = strings.ToLower(name)
 			codecByName[name] = c
-			if strings.Count(name, "/") == 1 {
-				codecByName[name+"/1"] = c
-			}
 		}
 	})
 }
 
 // CodecByNameWith finds the codec with a given SDP name.
 // If the codec is not found or disabled in the codec set, it returns nil.
-func CodecByNameWith(s *media.CodecSet, name string, params media.CodecParams) media.Codec {
+func CodecByNameWith(s *media.CodecSet, name string) media.CodecType {
 	if s == nil {
 		s = media.GlobalCodecs()
+	}
+	if i := strings.IndexByte(name, '/'); i >= 0 {
+		name = name[:i]
 	}
 	c := codecByName[strings.ToLower(name)]
 	if !s.IsEnabled(c) {
 		return nil
-	}
-	for _, p := range c.Info().ReqParams {
-		if val, ok := params.Get(p.Key); ok && val != p.Val {
-			return nil
-		}
 	}
 	return c
 }
@@ -58,6 +53,6 @@ func CodecByNameWith(s *media.CodecSet, name string, params media.CodecParams) m
 // CodecByName finds the codec with a given SDP name.
 //
 // Deprecated: use CodecByNameWith
-func CodecByName(name string) media.Codec {
-	return CodecByNameWith(media.GlobalCodecs(), name, nil)
+func CodecByName(name string) media.CodecType {
+	return CodecByNameWith(media.GlobalCodecs(), name)
 }

--- a/sdp/offer.go
+++ b/sdp/offer.go
@@ -49,7 +49,8 @@ const (
 
 type CodecInfo struct {
 	Type  byte
-	Codec media.Codec
+	Codec media.CodecType
+	Info  media.CodecInfo
 }
 
 // OfferCodecsWith lists enabled codecs in the set for the SDP offer and assigns payload types to them.
@@ -59,13 +60,10 @@ func OfferCodecsWith(s *media.CodecSet) []CodecInfo {
 	}
 	const dynamicType = 101
 	codecs := s.ListEnabled()
-	slices.SortFunc(codecs, func(a, b media.Codec) int {
+	slices.SortFunc(codecs, func(a, b media.CodecType) int {
 		ai, bi := a.Info(), b.Info()
 		if ai.Priority == bi.Priority {
-			if ai.SampleRate != bi.SampleRate {
-				return bi.SampleRate - ai.SampleRate
-			}
-			return strings.Compare(ai.SDPName, bi.SDPName)
+			return strings.Compare(ai.SDPName(), bi.SDPName())
 		}
 		return bi.Priority - ai.Priority
 	})
@@ -73,17 +71,20 @@ func OfferCodecsWith(s *media.CodecSet) []CodecInfo {
 	nextType := byte(dynamicType)
 	for _, c := range codecs {
 		cinfo := c.Info()
-		info := CodecInfo{
-			Codec: c,
+		for _, ci := range c.Offer(s) {
+			info := CodecInfo{
+				Codec: c,
+				Info:  ci,
+			}
+			if cinfo.RTPIsStatic {
+				info.Type = cinfo.RTPDefType
+			} else {
+				typ := nextType
+				nextType++
+				info.Type = typ
+			}
+			infos = append(infos, info)
 		}
-		if cinfo.RTPIsStatic {
-			info.Type = cinfo.RTPDefType
-		} else {
-			typ := nextType
-			nextType++
-			info.Type = typ
-		}
-		infos = append(infos, info)
 	}
 	return infos
 }
@@ -95,14 +96,10 @@ func OfferCodecs() []CodecInfo {
 	return OfferCodecsWith(media.GlobalCodecs())
 }
 
-type DTMFInfo struct {
-	Type byte
-	Rate int
-}
-
 type MediaDesc struct {
-	Codecs         []CodecInfo
-	DTMF           []DTMFInfo
+	Audio          []CodecInfo
+	Data           []CodecInfo
+	Unknown        []CodecInfo
 	CryptoProfiles []srtp.Profile
 	Direction      sdp.Direction
 }
@@ -135,58 +132,32 @@ func OfferMediaWith(s *media.CodecSet, rtpListenerPort int, encrypted Encryption
 	codecs := OfferCodecsWith(s)
 	attrs := make([]sdp.Attribute, 0, len(codecs)+4)
 	formats := make([]string, 0, len(codecs))
-	var dtmfTypes = make(map[int]byte)
-	// Index supported DTMF rates first.
-	for _, codec := range codecs {
-		ci := codec.Codec.Info()
-		if strings.HasPrefix(ci.SDPName, dtmf.SDPNameOnly+"/") {
-			dtmfTypes[ci.RTPClockRate] = codec.Type
-		}
-	}
 	var (
-		ratesForDTMF []int
-		audioCodecs  []CodecInfo
+		audioCodecs []CodecInfo
+		dataCodecs  []CodecInfo
 	)
 	for _, codec := range codecs {
-		ci := codec.Codec.Info()
-		if strings.HasPrefix(ci.SDPName, dtmf.SDPNameOnly+"/") {
+		ci := codec.Info
+		switch codec.Info.Kind {
+		default:
 			continue
-		}
-		audioCodecs = append(audioCodecs, codec)
-
-		dtmfRate := ci.RTPClockRate
-		if _, ok := dtmfTypes[dtmfRate]; ok && !slices.Contains(ratesForDTMF, dtmfRate) {
-			ratesForDTMF = append(ratesForDTMF, dtmfRate)
+		case media.Audio:
+			audioCodecs = append(audioCodecs, codec)
+		case media.Data:
+			dataCodecs = append(dataCodecs, codec)
 		}
 		styp := strconv.Itoa(int(codec.Type))
 		formats = append(formats, styp)
 		attrs = append(attrs, sdp.Attribute{
 			Key:   "rtpmap",
-			Value: styp + " " + ci.SDPName,
+			Value: fmt.Sprintf("%s %s", styp, ci.SDPFullName()),
 		})
-		if len(ci.ReqParams) != 0 {
+		if len(ci.Params) != 0 {
 			attrs = append(attrs, sdp.Attribute{
 				Key:   "fmtp",
-				Value: styp + " " + ci.ReqParams.String(),
+				Value: styp + " " + ci.Params.String(),
 			})
 		}
-	}
-	slices.Sort(ratesForDTMF)
-	var dtmfList []DTMFInfo
-	for _, rate := range ratesForDTMF {
-		typ, ok := dtmfTypes[rate]
-		if !ok {
-			continue
-		}
-		dtmfList = append(dtmfList, DTMFInfo{Type: typ, Rate: rate})
-		styp := strconv.Itoa(int(typ))
-		formats = append(formats, styp)
-		attrs = append(attrs, sdp.Attribute{
-			Key:   "rtpmap",
-			Value: fmt.Sprintf("%s %s/%d", styp, dtmf.SDPNameOnly, rate),
-		}, sdp.Attribute{
-			Key: "fmtp", Value: fmt.Sprintf("%d 0-16", typ),
-		})
 	}
 	var cryptoProfiles []srtp.Profile
 	if encrypted != EncryptionNone {
@@ -208,8 +179,8 @@ func OfferMediaWith(s *media.CodecSet, rtpListenerPort int, encrypted Encryption
 		proto = "SAVP"
 	}
 	return MediaDesc{
-			Codecs:         audioCodecs,
-			DTMF:           dtmfList,
+			Audio:          audioCodecs,
+			Data:           dataCodecs,
 			CryptoProfiles: cryptoProfiles,
 		}, &sdp.MediaDescription{
 			MediaName: sdp.MediaName{
@@ -234,24 +205,29 @@ func AnswerMedia(rtpListenerPort int, audio *AudioConfig, crypt *srtp.Profile) *
 	// Static compiler check for frame duration hardcoded below.
 	var _ = [1]struct{}{}[20*time.Millisecond-rtp.DefFrameDur]
 
+	formats := make([]string, 0, 2)
 	attrs := make([]sdp.Attribute, 0, 7)
-	ac := audio.Codec.Info()
+
+	ac := audio.Info
+	formats = append(formats, strconv.Itoa(int(audio.Type)))
 	attrs = append(attrs, sdp.Attribute{
-		Key: "rtpmap", Value: fmt.Sprintf("%d %s", audio.Type, ac.SDPName),
+		Key: "rtpmap", Value: fmt.Sprintf("%d %s", audio.Type, ac.SDPFullName()),
 	})
-	if len(ac.ReqParams) != 0 {
+	if len(ac.Params) != 0 {
 		attrs = append(attrs, sdp.Attribute{
-			Key: "fmtp", Value: fmt.Sprintf("%d %s", audio.Type, ac.ReqParams.String()),
+			Key: "fmtp", Value: fmt.Sprintf("%d %s", audio.Type, ac.Params.String()),
 		})
 	}
-	formats := make([]string, 0, 2)
-	formats = append(formats, strconv.Itoa(int(audio.Type)))
 	if d := audio.DTMF; d != nil {
 		formats = append(formats, strconv.Itoa(int(d.Type)))
-		attrs = append(attrs, []sdp.Attribute{
-			{Key: "rtpmap", Value: fmt.Sprintf("%d %s/%d", d.Type, dtmf.SDPNameOnly, d.Rate)},
-			{Key: "fmtp", Value: fmt.Sprintf("%d 0-16", d.Type)},
-		}...)
+		attrs = append(attrs, sdp.Attribute{
+			Key: "rtpmap", Value: fmt.Sprintf("%d %s", d.Type, d.Info.SDPFullName()),
+		})
+		if len(d.Info.Params) != 0 {
+			attrs = append(attrs, sdp.Attribute{
+				Key: "fmtp", Value: fmt.Sprintf("%d %s", d.Type, d.Info.Params.String()),
+			})
+		}
 	}
 	proto := "AVP"
 	if crypt != nil {
@@ -402,18 +378,16 @@ func (d *Offer) Answer(publicIp netip.Addr, rtpListenerPort int, enc Encryption,
 		MediaDescriptions: []*sdp.MediaDescription{mediaDesc},
 	}
 	src := netip.AddrPortFrom(publicIp, uint16(rtpListenerPort))
-	var dtmfList []DTMFInfo
+	var dataCodecs []CodecInfo
 	if d := audio.DTMF; d != nil {
-		dtmfList = []DTMFInfo{*d}
+		dataCodecs = []CodecInfo{*d}
 	}
 	return &Answer{
 			SDP:  answer,
 			Addr: src,
 			MediaDesc: MediaDesc{
-				Codecs: []CodecInfo{
-					{Type: audio.Type, Codec: audio.Codec},
-				},
-				DTMF: dtmfList,
+				Audio: []CodecInfo{audio.CodecInfo},
+				Data:  dataCodecs,
 			},
 		}, &MediaConfig{
 			Local:         src,
@@ -719,7 +693,7 @@ func ParseMediaWith(s *media.CodecSet, d *sdp.MediaDescription) (*MediaDesc, err
 	type codecInfo struct {
 		Type   int
 		Name   string
-		Params media.CodecParams
+		Config media.CodecConfig
 	}
 	var (
 		out    MediaDesc
@@ -746,21 +720,26 @@ func ParseMediaWith(s *media.CodecSet, d *sdp.MediaDescription) (*MediaDesc, err
 			if err != nil {
 				continue
 			}
-			name := sub[1]
-			if par, ok := strings.CutPrefix(name, dtmf.SDPNameOnly+"/"); ok {
-				srate := par
-				if i := strings.IndexByte(srate, '/'); i != -1 {
-					srate = srate[:i]
-				}
-				rate, err := strconv.Atoi(srate)
+			sname := strings.SplitN(sub[1], "/", 4)
+			if len(sname) < 2 || len(sname) > 3 {
+				continue
+			}
+			name := sname[0]
+			rate, err := strconv.Atoi(sname[1])
+			if err != nil {
+				continue
+			}
+			channels := 0
+			if len(sname) > 2 {
+				channels, err = strconv.Atoi(sname[2])
 				if err != nil {
 					continue
 				}
-				out.DTMF = append(out.DTMF, DTMFInfo{Type: byte(typ), Rate: rate})
-				continue
 			}
 			c := getCodec(typ)
 			c.Name = name
+			c.Config.SampleRate = rate
+			c.Config.Channels = channels
 		case "fmtp":
 			sub := strings.SplitN(m.Value, " ", 2)
 			if len(sub) != 2 {
@@ -777,7 +756,7 @@ func ParseMediaWith(s *media.CodecSet, d *sdp.MediaDescription) (*MediaDesc, err
 					p.Key = par[:i]
 					p.Val = par[i+1:]
 				}
-				c.Params = append(c.Params, p)
+				c.Config.Params = append(c.Config.Params, p)
 			}
 		case "crypto":
 			p, err := parseSRTPProfile(m.Value)
@@ -804,24 +783,36 @@ func ParseMediaWith(s *media.CodecSet, d *sdp.MediaDescription) (*MediaDesc, err
 		_ = c // just add
 	}
 	for _, ci := range codecs {
-		if slices.ContainsFunc(out.DTMF, func(d DTMFInfo) bool {
-			return d.Type == byte(ci.Type)
-		}) {
-			continue
-		}
-		var codec media.AudioCodec
+		var codec media.CodecType
 		if ci.Name != "" {
-			codec, _ = CodecByNameWith(s, ci.Name, ci.Params).(media.AudioCodec)
+			codec = CodecByNameWith(s, ci.Name)
 		} else {
-			codec, _ = rtp.CodecByPayloadType(byte(ci.Type)).(media.AudioCodec)
+			codec = rtp.CodecByPayloadType(byte(ci.Type))
 			if !s.IsEnabled(codec) {
 				codec = nil
 			}
 		}
-		out.Codecs = append(out.Codecs, CodecInfo{
+		var info media.CodecInfo
+		if codec != nil {
+			var ok bool
+			info, _, ok = codec.Supports(ci.Config)
+			if !ok {
+				codec = nil
+			}
+		}
+		ci := CodecInfo{
 			Type:  byte(ci.Type),
 			Codec: codec,
-		})
+			Info:  info,
+		}
+		switch info.Kind {
+		case media.Audio:
+			out.Audio = append(out.Audio, ci)
+		case media.Data:
+			out.Data = append(out.Data, ci)
+		default:
+			out.Unknown = append(out.Unknown, ci)
+		}
 	}
 	return &out, nil
 }
@@ -842,27 +833,25 @@ type MediaConfig struct {
 	PeerDirection sdp.Direction // RFC 3264, offer direction for server, answer direction for client
 }
 
+type DTMFInfo struct {
+	Type byte
+	Rate int
+}
+
 type AudioConfig struct {
-	Codec media.AudioCodec
-	Type  byte
-	DTMF  *DTMFInfo
+	CodecInfo
+	DTMF *CodecInfo
 }
 
 func SelectAudio(desc MediaDesc, answer bool) (*AudioConfig, error) {
 	var (
 		priority   int
-		audioCodec media.AudioCodec
-		audioType  byte
+		audioCodec *CodecInfo
 	)
-	for _, c := range desc.Codecs {
-		codec, ok := c.Codec.(media.AudioCodec)
-		if !ok {
-			continue
-		}
-		if audioCodec == nil || codec.Info().Priority > priority {
-			audioType = c.Type
-			audioCodec = codec
-			priority = codec.Info().Priority
+	for _, c := range desc.Audio {
+		if audioCodec == nil || c.Info.Priority > priority {
+			audioCodec = &c
+			priority = c.Info.Priority
 		}
 		if answer {
 			break
@@ -871,30 +860,31 @@ func SelectAudio(desc MediaDesc, answer bool) (*AudioConfig, error) {
 	if audioCodec == nil {
 		return nil, ErrNoCommonMedia
 	}
-	audioInfo := audioCodec.Info()
-	c := &AudioConfig{
-		Codec: audioCodec,
-		Type:  audioType,
+	a := &AudioConfig{
+		CodecInfo: *audioCodec,
 	}
-	di := slices.IndexFunc(desc.DTMF, func(d DTMFInfo) bool {
-		return d.Rate == audioInfo.RTPClockRate
+	di := slices.IndexFunc(desc.Data, func(d CodecInfo) bool {
+		return d.Info.Name == dtmf.SDPNameOnly && d.Info.RTPClockRate == a.Info.RTPClockRate
 	})
 	if di < 0 {
 		maxRate := -1
-		for i, d := range desc.DTMF {
-			if d.Rate > audioInfo.RTPClockRate {
+		for i, d := range desc.Data {
+			if d.Info.Name != dtmf.SDPNameOnly {
 				continue
 			}
-			if maxRate < 0 || d.Rate > maxRate {
-				maxRate = d.Rate
+			if d.Info.RTPClockRate > a.Info.RTPClockRate {
+				continue
+			}
+			if maxRate < 0 || d.Info.RTPClockRate > maxRate {
+				maxRate = d.Info.RTPClockRate
 				di = i
 			}
 		}
 	}
 	if di >= 0 {
-		c.DTMF = new(desc.DTMF[di])
+		a.DTMF = new(desc.Data[di])
 	}
-	return c, nil
+	return a, nil
 }
 
 func SelectCrypto(offer, answer []srtp.Profile, swap bool) (*srtp.Config, *srtp.Profile, error) {

--- a/sdp/offer.go
+++ b/sdp/offer.go
@@ -53,6 +53,15 @@ type CodecInfo struct {
 	Info  media.CodecInfo
 }
 
+func (c *CodecInfo) Equals(c2 *CodecInfo) bool {
+	if c == nil && c2 == nil {
+		return true
+	} else if c == nil || c2 == nil {
+		return false
+	}
+	return c.Type == c2.Type && c.Info.Equals(&c2.Info)
+}
+
 // OfferCodecsWith lists enabled codecs in the set for the SDP offer and assigns payload types to them.
 func OfferCodecsWith(s *media.CodecSet) []CodecInfo {
 	if s == nil {
@@ -831,11 +840,6 @@ type MediaConfig struct {
 	Audio         AudioConfig
 	Crypto        *srtp.Config
 	PeerDirection sdp.Direction // RFC 3264, offer direction for server, answer direction for client
-}
-
-type DTMFInfo struct {
-	Type byte
-	Rate int
 }
 
 type AudioConfig struct {

--- a/sdp/offer_test.go
+++ b/sdp/offer_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/livekit/media-sdk"
 	"github.com/livekit/media-sdk/amrwb"
+	"github.com/livekit/media-sdk/dtmf"
 	"github.com/livekit/media-sdk/g711"
 	"github.com/livekit/media-sdk/g722"
 	"github.com/livekit/media-sdk/rtp"
@@ -68,7 +69,7 @@ func TestSDPMediaOffer(t *testing.T) {
 		},
 		Attributes: []sdp.Attribute{
 			{Key: "rtpmap", Value: "101 AMR-WB/16000"},
-			{Key: "fmtp", Value: "101 octet-align=0"},
+			{Key: "fmtp", Value: "101 octet-align=0;mode-set=8"},
 			{Key: "rtpmap", Value: "9 G722/8000"},
 			{Key: "rtpmap", Value: "0 PCMU/8000"},
 			{Key: "rtpmap", Value: "8 PCMA/8000"},
@@ -96,7 +97,7 @@ func TestSDPMediaOffer(t *testing.T) {
 		},
 		Attributes: []sdp.Attribute{
 			{Key: "rtpmap", Value: "101 AMR-WB/16000"},
-			{Key: "fmtp", Value: "101 octet-align=0"},
+			{Key: "fmtp", Value: "101 octet-align=0;mode-set=8"},
 			{Key: "rtpmap", Value: "9 G722/8000"},
 			{Key: "rtpmap", Value: "0 PCMU/8000"},
 			{Key: "rtpmap", Value: "8 PCMA/8000"},
@@ -116,6 +117,7 @@ func TestSDPMediaOffer(t *testing.T) {
 	g2 := g.NewSet()
 	g2.SetEnabled(g722.SDPNameAndRate, false)
 	g2.SetEnabled(amrwb.SDPNameAndRate, false)
+	g2.SetEnabled("opus", false)
 
 	_, offer, err = OfferMediaWith(g2, port, EncryptionNone)
 	require.NoError(t, err)
@@ -137,13 +139,77 @@ func TestSDPMediaOffer(t *testing.T) {
 	}, offer)
 }
 
-func getCodec(s *media.CodecSet, name string, params ...media.CodecParam) media.AudioCodec {
-	return CodecByNameWith(s, name, params).(media.AudioCodec)
+func getCodec(s *media.CodecSet, name string) media.CodecType {
+	return CodecByNameWith(s, name)
+}
+
+func dtmfCodec(s *media.CodecSet, typ byte, rate, ch int) *CodecInfo {
+	const name = dtmf.SDPNameOnly
+	c := getCodec(s, name)
+	ci := c.Info()
+	return &CodecInfo{
+		Type:  typ,
+		Codec: c,
+		Info: media.CodecInfo{
+			CodecTypeInfo: media.CodecTypeInfo{
+				Name:     name,
+				Kind:     media.Data,
+				Priority: ci.Priority - rate/8000,
+				FileExt:  ci.FileExt,
+			},
+			CodecConfig: media.CodecConfig{
+				SampleRate: rate,
+				Channels:   ch,
+				Params:     media.CodecParams{{Key: "0-16"}},
+			},
+			RTPClockRate: rate,
+		},
+	}
+}
+
+func staticCodec(s *media.CodecSet, typ byte, name string, rtpRate int, cc media.CodecConfig) CodecInfo {
+	c := getCodec(s, name)
+	ci := c.Info()
+	return CodecInfo{
+		Type:  typ,
+		Codec: c,
+		Info: media.CodecInfo{
+			CodecTypeInfo: media.CodecTypeInfo{
+				Name:        name,
+				Kind:        media.Audio,
+				RTPDefType:  typ,
+				RTPIsStatic: true,
+				Priority:    ci.Priority,
+				FileExt:     ci.FileExt,
+			},
+			CodecConfig:  cc,
+			RTPClockRate: rtpRate,
+		},
+	}
+}
+func dynamicCodec(s *media.CodecSet, typ byte, name string, rtpRate int, cc media.CodecConfig) CodecInfo {
+	c := getCodec(s, name)
+	ci := c.Info()
+	return CodecInfo{
+		Type:  typ,
+		Codec: c,
+		Info: media.CodecInfo{
+			CodecTypeInfo: media.CodecTypeInfo{
+				Name:     name,
+				Kind:     media.Audio,
+				Priority: ci.Priority,
+				FileExt:  ci.FileExt,
+			},
+			CodecConfig:  cc,
+			RTPClockRate: rtpRate,
+		},
+	}
 }
 
 func TestSDPMediaAnswer(t *testing.T) {
 	g := codecSet()
 	const port = 12345
+
 	cases := []struct {
 		name  string
 		offer sdp.MediaDescription
@@ -162,9 +228,8 @@ func TestSDPMediaAnswer(t *testing.T) {
 				},
 			},
 			exp: &AudioConfig{
-				Codec: getCodec(g, g722.SDPNameAndRate),
-				Type:  9,
-				DTMF:  &DTMFInfo{Type: 101, Rate: 8000},
+				CodecInfo: staticCodec(g, 9, g722.SDPNameOnly, 8000, media.CodecConfig{SampleRate: 16000}),
+				DTMF:      dtmfCodec(g, 101, 8000, 0),
 			},
 		},
 		{
@@ -180,9 +245,8 @@ func TestSDPMediaAnswer(t *testing.T) {
 				},
 			},
 			exp: &AudioConfig{
-				Codec: getCodec(g, g722.SDPNameAndRate),
-				Type:  9,
-				DTMF:  &DTMFInfo{Type: 101, Rate: 8000},
+				CodecInfo: staticCodec(g, 9, g722.SDPNameOnly, 8000, media.CodecConfig{SampleRate: 16000}),
+				DTMF:      dtmfCodec(g, 101, 8000, 0),
 			},
 		},
 		{
@@ -197,8 +261,7 @@ func TestSDPMediaAnswer(t *testing.T) {
 				},
 			},
 			exp: &AudioConfig{
-				Codec: getCodec(g, g722.SDPNameAndRate),
-				Type:  9,
+				CodecInfo: staticCodec(g, 9, g722.SDPNameOnly, 8000, media.CodecConfig{SampleRate: 16000}),
 			},
 		},
 		{
@@ -214,9 +277,8 @@ func TestSDPMediaAnswer(t *testing.T) {
 				},
 			},
 			exp: &AudioConfig{
-				Codec: getCodec(g, g722.SDPNameAndRate),
-				Type:  9,
-				DTMF:  &DTMFInfo{Type: 103, Rate: 8000},
+				CodecInfo: staticCodec(g, 9, g722.SDPNameOnly, 8000, media.CodecConfig{SampleRate: 16000}),
+				DTMF:      dtmfCodec(g, 103, 8000, 0),
 			},
 		},
 		{
@@ -232,9 +294,8 @@ func TestSDPMediaAnswer(t *testing.T) {
 				},
 			},
 			exp: &AudioConfig{
-				Codec: getCodec(g, g711.ULawSDPNameAndRate),
-				Type:  0,
-				DTMF:  &DTMFInfo{Type: 101, Rate: 8000},
+				CodecInfo: staticCodec(g, 0, g711.ULawSDPNameOnly, 8000, media.CodecConfig{SampleRate: 8000}),
+				DTMF:      dtmfCodec(g, 101, 8000, 0),
 			},
 		},
 		{
@@ -250,9 +311,8 @@ func TestSDPMediaAnswer(t *testing.T) {
 				},
 			},
 			exp: &AudioConfig{
-				Codec: getCodec(g, g722.SDPNameAndRate),
-				Type:  9,
-				DTMF:  &DTMFInfo{Type: 101, Rate: 8000},
+				CodecInfo: staticCodec(g, 9, g722.SDPNameOnly, 8000, media.CodecConfig{SampleRate: 16000}),
+				DTMF:      dtmfCodec(g, 101, 8000, 0),
 			},
 		},
 		{
@@ -279,9 +339,8 @@ func TestSDPMediaAnswer(t *testing.T) {
 				},
 			},
 			exp: &AudioConfig{
-				Codec: getCodec(g, g711.ULawSDPNameAndRate),
-				Type:  0,
-				DTMF:  &DTMFInfo{Type: 101, Rate: 8000},
+				CodecInfo: staticCodec(g, 0, g711.ULawSDPNameOnly, 8000, media.CodecConfig{SampleRate: 8000}),
+				DTMF:      dtmfCodec(g, 101, 8000, 0),
 			},
 		},
 		{
@@ -293,13 +352,12 @@ func TestSDPMediaAnswer(t *testing.T) {
 				},
 			},
 			exp: &AudioConfig{
-				Codec: getCodec(g, g711.ULawSDPNameAndRate),
-				Type:  0,
-				DTMF:  &DTMFInfo{Type: 101, Rate: 8000},
+				CodecInfo: staticCodec(g, 0, g711.ULawSDPNameOnly, 8000, media.CodecConfig{SampleRate: 8000, Channels: 1}),
+				DTMF:      dtmfCodec(g, 101, 8000, 1),
 			},
 		},
 		{
-			name: "changed order",
+			name: "changed order g722",
 			offer: sdp.MediaDescription{
 				MediaName: sdp.MediaName{
 					Formats: []string{"0", "9"},
@@ -310,8 +368,7 @@ func TestSDPMediaAnswer(t *testing.T) {
 				},
 			},
 			exp: &AudioConfig{
-				Codec: getCodec(g, g711.ULawSDPNameAndRate),
-				Type:  0,
+				CodecInfo: staticCodec(g, 0, g711.ULawSDPNameOnly, 8000, media.CodecConfig{SampleRate: 8000}),
 			},
 		},
 		{
@@ -326,8 +383,7 @@ func TestSDPMediaAnswer(t *testing.T) {
 				},
 			},
 			exp: &AudioConfig{
-				Codec: getCodec(g, g711.ALawSDPNameAndRate),
-				Type:  8,
+				CodecInfo: staticCodec(g, 8, g711.ALawSDPNameOnly, 8000, media.CodecConfig{SampleRate: 8000}),
 			},
 		},
 		{
@@ -343,8 +399,9 @@ func TestSDPMediaAnswer(t *testing.T) {
 			},
 			exp: &AudioConfig{
 				// Pick AMR-WB, assume missing parameter matches ours.
-				Codec: getCodec(g, amrwb.SDPNameAndRate, media.CodecParam{"octet-align", "0"}),
-				Type:  101,
+				CodecInfo: dynamicCodec(g, 101, amrwb.SDPNameOnly, 16000, media.CodecConfig{SampleRate: 16000, Params: media.CodecParams{
+					{Key: "octet-align", Val: "0"}, {Key: "mode-set", Val: "8"},
+				}}),
 			},
 		},
 		{
@@ -362,9 +419,10 @@ func TestSDPMediaAnswer(t *testing.T) {
 			},
 			exp: &AudioConfig{
 				// Pick AMR-WB, assume missing parameter matches ours.
-				Codec: getCodec(g, amrwb.SDPNameAndRate, media.CodecParam{"octet-align", "0"}),
-				Type:  101,
-				DTMF:  &DTMFInfo{Type: 104, Rate: 16000},
+				CodecInfo: dynamicCodec(g, 101, amrwb.SDPNameOnly, 16000, media.CodecConfig{SampleRate: 16000, Params: media.CodecParams{
+					{Key: "octet-align", Val: "0"}, {Key: "mode-set", Val: "8"},
+				}}),
+				DTMF: dtmfCodec(g, 104, 16000, 0),
 			},
 		},
 		{
@@ -381,9 +439,10 @@ func TestSDPMediaAnswer(t *testing.T) {
 			},
 			exp: &AudioConfig{
 				// Pick AMR-WB, assume missing parameter matches ours.
-				Codec: getCodec(g, amrwb.SDPNameAndRate, media.CodecParam{"octet-align", "0"}),
-				Type:  101,
-				DTMF:  &DTMFInfo{Type: 103, Rate: 8000},
+				CodecInfo: dynamicCodec(g, 101, amrwb.SDPNameOnly, 16000, media.CodecConfig{SampleRate: 16000, Params: media.CodecParams{
+					{Key: "octet-align", Val: "0"}, {Key: "mode-set", Val: "8"},
+				}}),
+				DTMF: dtmfCodec(g, 103, 8000, 0),
 			},
 		},
 		{
@@ -400,8 +459,9 @@ func TestSDPMediaAnswer(t *testing.T) {
 			},
 			exp: &AudioConfig{
 				// Pick AMR-WB, encoding matches, ignore other params.
-				Codec: getCodec(g, amrwb.SDPNameAndRate, media.CodecParam{"octet-align", "0"}),
-				Type:  101,
+				CodecInfo: dynamicCodec(g, 101, amrwb.SDPNameOnly, 16000, media.CodecConfig{SampleRate: 16000, Params: media.CodecParams{
+					{Key: "octet-align", Val: "0"}, {Key: "mode-set", Val: "8"},
+				}}),
 			},
 		},
 		{
@@ -417,9 +477,27 @@ func TestSDPMediaAnswer(t *testing.T) {
 				},
 			},
 			exp: &AudioConfig{
-				// Pick PCMU, encoding doesn't match.
-				Codec: getCodec(g, g711.ULawSDPNameAndRate),
-				Type:  0,
+				// Pick PCMU, AMR-WB encoding doesn't match.
+				CodecInfo: staticCodec(g, 0, g711.ULawSDPNameOnly, 8000, media.CodecConfig{SampleRate: 8000}),
+			},
+		},
+		{
+			name: "amrwb mode set",
+			offer: sdp.MediaDescription{
+				MediaName: sdp.MediaName{
+					Formats: []string{"101", "0"},
+				},
+				Attributes: []sdp.Attribute{
+					{Key: "rtpmap", Value: "101 AMR-WB/16000"},
+					{Key: "fmtp", Value: "101 octet-align=0;mode-set=0,1,2;mode-change-capability=2"},
+					{Key: "rtpmap", Value: "0 PCMU/8000"},
+				},
+			},
+			exp: &AudioConfig{
+				// Pick AMR-WB and the highest mode available.
+				CodecInfo: dynamicCodec(g, 101, amrwb.SDPNameOnly, 16000, media.CodecConfig{SampleRate: 16000, Params: media.CodecParams{
+					{Key: "octet-align", Val: "0"}, {Key: "mode-set", Val: "2"},
+				}}),
 			},
 		},
 	}
@@ -438,6 +516,7 @@ func TestSDPMediaAnswer(t *testing.T) {
 			require.Equal(t, c.exp, got)
 		})
 	}
+
 	t.Run("default offer and answer", func(t *testing.T) {
 		desc, offer, err := OfferMediaWith(g, port, EncryptionNone)
 		require.NoError(t, err)
@@ -450,7 +529,7 @@ func TestSDPMediaAnswer(t *testing.T) {
 			},
 			Attributes: []sdp.Attribute{
 				{Key: "rtpmap", Value: "101 AMR-WB/16000"},
-				{Key: "fmtp", Value: "101 octet-align=0"},
+				{Key: "fmtp", Value: "101 octet-align=0;mode-set=8"},
 				{Key: "rtpmap", Value: "9 G722/8000"},
 				{Key: "rtpmap", Value: "0 PCMU/8000"},
 				{Key: "rtpmap", Value: "8 PCMA/8000"},
@@ -464,12 +543,13 @@ func TestSDPMediaAnswer(t *testing.T) {
 		}, offer)
 
 		var audioCodecs []string
-		for _, c := range desc.Codecs {
+		for _, c := range desc.Audio {
 			name := ""
+			rate := c.Info.RTPClockRate
 			if cc := c.Codec; cc != nil {
-				name = cc.Info().SDPName
+				name = cc.SDPName()
 			}
-			audioCodecs = append(audioCodecs, fmt.Sprintf("%d = %s", int(c.Type), name))
+			audioCodecs = append(audioCodecs, fmt.Sprintf("%d = %s/%d", int(c.Type), name, rate))
 		}
 		require.Equal(t, []string{
 			"101 = AMR-WB/16000",
@@ -491,7 +571,7 @@ func TestSDPMediaAnswer(t *testing.T) {
 			},
 			Attributes: []sdp.Attribute{
 				{Key: "rtpmap", Value: "101 AMR-WB/16000"},
-				{Key: "fmtp", Value: "101 octet-align=0"},
+				{Key: "fmtp", Value: "101 octet-align=0;mode-set=8"},
 				{Key: "rtpmap", Value: "103 telephone-event/16000"},
 				{Key: "fmtp", Value: "103 0-16"},
 				{Key: "ptime", Value: "20"},
@@ -515,9 +595,8 @@ func TestSDPMediaAnswerOneDisabled(t *testing.T) {
 		},
 	}
 	exp := &AudioConfig{
-		Codec: getCodec(g, g711.ULawSDPNameAndRate),
-		Type:  0,
-		DTMF:  &DTMFInfo{Type: 101, Rate: 8000},
+		CodecInfo: staticCodec(g, 0, g711.ULawSDPNameOnly, 8000, media.CodecConfig{SampleRate: 8000}),
+		DTMF:      dtmfCodec(g, 101, 8000, 0),
 	}
 
 	noG722 := g.NewSet()


### PR DESCRIPTION
Refactor codec definitions to allow parsing and negotiating codec parameters (`fmtp`).

Addresses #87 