### PR TITLE
Allow both RTP and real rate for G722. Use RTP rate for DTMF.

### DIFF
--- a/dtmf/dtmf.go
+++ b/dtmf/dtmf.go
@@ -47,7 +47,7 @@ func init() {
 				continue
 			}
 			for _, cc := range c.Offer(s) {
-				rate := cc.SampleRate
+				rate := cc.RTPClockRate
 				if rate <= 0 {
 					continue
 				}

--- a/g722/g722.go
+++ b/g722/g722.go
@@ -50,16 +50,19 @@ func init() {
 		if c.Channels != 0 && c.Channels != 1 {
 			return media.CodecInfo{}, nil, false
 		}
-		const sdpRate = 8000 // known error in RFC
+		const (
+			realRate = 16000
+			rtpRate  = 8000 // known error in RFC
+		)
 		if c.SampleRate == 0 {
-			c.SampleRate = sdpRate
+			c.SampleRate = realRate
 		}
-		if c.SampleRate != sdpRate {
+		if c.SampleRate != rtpRate && c.SampleRate != realRate {
 			return media.CodecInfo{}, nil, false
 		}
 		info := media.CodecInfo{CodecTypeInfo: info, CodecConfig: c}
-		info.SampleRate = 16000
-		info.RTPClockRate = sdpRate
+		info.SampleRate = realRate
+		info.RTPClockRate = rtpRate
 		info.Params = nil
 		create := media.NewAudioCodecFunc(info, Decode, Encode)
 		return info, create, true


### PR DESCRIPTION
Allow both the real rate and for RTP/SDP rate for G722 when checking for supported configurations. Otherwise it becomes tricky as the caller would need to know to overwrite the real codec sample rate with RTP rate.

Also, use RTP clock rate for DTMF, instead of the real sample rate.

This is hotfix for https://github.com/livekit/media-sdk/pull/88