### PR TITLE
Allow offering 8K DTMF, even if codec has higher sample rate.

### DIFF
--- a/dtmf/dtmf.go
+++ b/dtmf/dtmf.go
@@ -31,6 +31,13 @@ const (
 	SDPNameOnly = "telephone-event"
 )
 
+// TODO(dennwc): These belong to a codec-specific offer/answer config. Consider adding argument to OfferFunc.
+
+var (
+	// OfferLegacyRate forces DTMF to advertise/negotiate 8000 sample rate, even if the codec has a higher sample rate.
+	OfferLegacyRate = false
+)
+
 func init() {
 	info := media.CodecTypeInfo{
 		Name:        SDPNameOnly,
@@ -41,6 +48,9 @@ func init() {
 	media.RegisterCodec(media.NewCodec(info, func(s *media.CodecSet) []media.CodecInfo {
 		// Check rates that other codecs advertise.
 		var rates []int
+		if OfferLegacyRate {
+			rates = append(rates, 8000)
+		}
 		for _, c := range s.ListEnabled() {
 			name := c.SDPName()
 			if name == SDPNameOnly {

--- a/sdp/offer_test.go
+++ b/sdp/offer_test.go
@@ -579,6 +579,36 @@ func TestSDPMediaAnswer(t *testing.T) {
 			},
 		}, answer)
 	})
+
+	t.Run("legacy offer", func(t *testing.T) {
+		// Check compatibility path - offer DTMF at 8000, even if codec is 16000.
+		dtmf.OfferLegacyRate = true
+		defer func() { dtmf.OfferLegacyRate = false }()
+		g := media.NewCodecSet()
+		g.SetEnabled(amrwb.SDPNameOnly, true)
+		g.SetEnabled(dtmf.SDPNameOnly, true)
+
+		_, offer, err := OfferMediaWith(g, port, EncryptionNone)
+		require.NoError(t, err)
+		require.Equal(t, &sdp.MediaDescription{
+			MediaName: sdp.MediaName{
+				Media:   "audio",
+				Port:    sdp.RangedPort{Value: port},
+				Protos:  []string{"RTP", "AVP"},
+				Formats: []string{"101", "102", "103"},
+			},
+			Attributes: []sdp.Attribute{
+				{Key: "rtpmap", Value: "101 AMR-WB/16000"},
+				{Key: "fmtp", Value: "101 octet-align=0;mode-set=8"},
+				{Key: "rtpmap", Value: "102 telephone-event/8000"},
+				{Key: "fmtp", Value: "102 0-16"},
+				{Key: "rtpmap", Value: "103 telephone-event/16000"},
+				{Key: "fmtp", Value: "103 0-16"},
+				{Key: "ptime", Value: "20"},
+				{Key: "sendrecv"},
+			},
+		}, offer)
+	})
 }
 
 func TestSDPMediaAnswerOneDisabled(t *testing.T) {


### PR DESCRIPTION
Background - This is to provide temporary backwards-compatibility with the enablement of `AMR-WB/16000` and the previously fixed DTMF rate. 